### PR TITLE
(SIMP-604) Migrate to simplib and simpcat

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,8 @@
 fixtures:
   repositories:
     common: "git://github.com/simp/pupmod-simp-common"
-    concat: "git://github.com/simp/pupmod-simp-concat"
+    simplib: "git://github.com/simp/pupmod-simp-simplib"
+    simpcat: "git://github.com/simp/pupmod-simp-concat"
     functions: "git://github.com/simp/pupmod-simp-functions"
     iptables: "git://github.com/simp/pupmod-simp-iptables"
     rsync: "git://github.com/simp/pupmod-simp-rsync"

--- a/.fixtures.yml.local
+++ b/.fixtures.yml.local
@@ -3,7 +3,8 @@ fixtures:
   symlinks:
     snmpd: "#{source_dir}"
     common: "#{source_dir}/../common"
-    concat: "#{source_dir}/../concat"
+    simplib: "#{source_dir}/../simplib"
+    simpcat: "#{source_dir}/../simpcat"
     functions: "#{source_dir}/../functions"
     iptables: "#{source_dir}/../iptables"
     rsync: "#{source_dir}/../rsync"

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,0 +1,5 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-variables_not_enclosed-check
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format documentation
+--color
+--fail-fast

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,71 @@
 ---
 language: ruby
 cache: bundler
+bundler_args: --without development system_tests
+before_install: rm Gemfile.lock || true
 rvm:
-    - 1.8.7
-    - 1.9.3
-    - 2.0.0
-    - 2.2.1
-install: bundle install
+#  - 1.8.7  # bombs out on mime-types
+  - 1.9.3
+  - 2.0.0
+  - 2.1.0
+  - 2.2.1
 script:
     - 'bundle exec rake validate'
     - 'bundle exec rake lint'
     - 'bundle exec rake spec'
+# NOTE: `:environmentpath` was not supported before Puppet 3.5
+env:
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
+
 matrix:
-    allow_failures:
-        - rvm: 1.8.7
-        - rvm: 2.2.1
+  fast_finish: true
+  allow_failures:
+    - rvm: 1.8.7
+    - rvm: 2.1.0
+    - rvm: 2.2.1
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
+
+  exclude:
+  # Ruby 1.8.7
+  # - Ruby 1.8.7 & Puppet 4.X is impossibru
+
+  # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
+  # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
+  # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+
+  # Ruby 1.9.3
+  - rvm: 1.9.3
+    env: PUPPET_VERSION="~> 2.7.0"
+
+  # Ruby 2.0.0
+  - rvm: 2.0.0
+    env: PUPPET_VERSION="~> 2.7.0"
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+
+  # Ruby 2.2.1
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.6.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-# Environment variables:
+# Variables:
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
@@ -7,17 +7,38 @@ gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[,
 
 gem_sources.each { |gem_source| source gem_source }
 
+group :test do
+  gem 'rake'
+  gem 'puppet', puppetversion
+  gem 'rspec', '< 3.2.0'
+  gem 'rspec-puppet'
+  gem 'puppetlabs_spec_helper'
+  gem 'metadata-json-lint'
+  gem 'simp-rspec-puppet-facts'
 
-gem 'puppet', puppetversion
-gem 'puppet-lint'
-gem 'puppetlabs_spec_helper'
-gem 'puppet_module_spec_helper'
-gem 'simp-rake-helpers'
+  # simp-rake-helpers does not suport puppet 2.7.X
+  # FIXME: simp-rake-helpers should support Puppet 4.X
+  if (!(['2','4'].include?( "#{ENV['PUPPET_VERSION']}".split('.').first)) &&
+      ("#{ENV['PUPPET_VERSION']}" !~ /~> ?(2|4)/ ? true : false) ) &&
+      # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
+      # TODO: fix upstream deps (parallel in simp-rake-helpers)
+      !( ENV['TRAVIS'] && RUBY_VERSION.sub(/\.\d+$/,'') == '1.8' )
+    gem 'simp-rake-helpers'
+  end
+end
 
-group :debug do
-    gem 'pry'
-    gem 'pry-doc'
-    gem 'rspec'
-    gem 'mocha'
-    gem 'metadata-json-lint'
+group :development do
+  gem 'travis'
+  gem 'travis-lint'
+  gem 'vagrant-wrapper'
+  gem 'puppet-blacksmith'
+  gem 'guard'
+  gem 'guard-rake'
+  gem 'pry'
+  gem 'pry-doc'
+end
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,27 +1,68 @@
-#!/usr/bin/rake -T
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet/version'
+require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
+require 'puppet-syntax/tasks/puppet-syntax'
+require 'puppet-lint/tasks/puppet-lint'
 
-# For playing nice with mock
-File.umask(027)
+# These gems aren't always present, for instance
+# on Travis with --without development
+begin
+  require 'puppet_blacksmith/rake_tasks'
+rescue LoadError
+end
 
-require 'simp/rake/pkg'
+
+# Lint & Syntax exclusions
+exclude_paths = [
+  "bundle/**/*",
+  "pkg/**/*",
+  "dist/**/*",
+  "vendor/**/*",
+  "spec/**/*",
+]
+PuppetSyntax.exclude_paths = exclude_paths
+
+# See: https://github.com/rodjek/puppet-lint/pull/397
+Rake::Task[:lint].clear
+PuppetLint.configuration.ignore_paths = exclude_paths
+PuppetLint::RakeTask.new :lint do |config|
+  config.ignore_paths = PuppetLint.configuration.ignore_paths
+end
 
 begin
-  require 'puppetlabs_spec_helper/rake_tasks'
+  require 'simp/rake/pkg'
+  Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
+    t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+  end
 rescue LoadError
-  puts "== WARNING: Gem puppetlabs_spec_helper not found, spec tests cannot be run! =="
+  puts "== WARNING: Gem simp-rake-helpers not found, pkg: tasks cannot be run! =="
 end
 
-# Lint Material
 begin
-  require 'puppet-lint/tasks/puppet-lint'
-
-  PuppetLint.configuration.send("disable_80chars")
-  PuppetLint.configuration.send("disable_variables_not_enclosed")
-  PuppetLint.configuration.send("disable_class_parameter_defaults")
+  require 'simp/rake/beaker'
+  Simp::Rake::Beaker.new( File.dirname( __FILE__ ) )
 rescue LoadError
-  puts "== WARNING: Gem puppet-lint not found, lint tests cannot be run! =="
+  # Ignoring this for now since all of these are currently convenience methods.
 end
 
-Simp::Rake::Pkg.new( File.dirname( __FILE__ ) ) do | t |
-  t.clean_list << "#{t.base_dir}/spec/fixtures/hieradata/hiera.yaml"
+desc "Run acceptance tests"
+RSpec::Core::RakeTask.new(:acceptance) do |t|
+  t.pattern = 'spec/acceptance'
 end
+
+desc "Populate CONTRIBUTORS file"
+task :contributors do
+  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
+end
+
+task :metadata do
+  sh "metadata-json-lint metadata.json"
+end
+
+desc "Run syntax, lint, and spec tests."
+task :test => [
+  :syntax,
+  :lint,
+  :spec,
+  :metadata,
+]

--- a/build/pupmod-snmpd.spec
+++ b/build/pupmod-snmpd.spec
@@ -1,13 +1,14 @@
 Summary: SNMP Puppet Module
 Name: pupmod-snmpd
 Version: 4.1.0
-Release: 3
+Release: 4
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: pupmod-common >= 2.1.2-2
-Requires: pupmod-concat >= 2.0.0-0
+Requires: pupmod-simplib >= 1.0.0-0
+Requires: pupmod-simpcat >= 2.0.0-0
 Requires: pupmod-functions >= 2.0.0-0
 Requires: pupmod-rsync >= 2.0.0-0
 Requires: puppet >= 3.3.0
@@ -63,6 +64,9 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-4
+- migration to simplib and simpcat (lib/ only)
+
 * Fri Jan 16 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 4.1.0-3
 - Changed puppet-server requirement to puppet
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,6 +35,10 @@ class snmpd (
   include 'functions'
 
 
+  validate_bool($dont_log_tcp_wrappers_connects)
+  validate_integer($agentgid)
+  validate_integer($agentuid)
+
   $l_fragdir = fragmentdir('snmpd')
   $l_outdir = concat_output('snmpd')
 
@@ -179,8 +183,4 @@ class snmpd (
       notify     => Service['snmpd']
     }
   }
-
-  validate_bool($dont_log_tcp_wrappers_connects)
-  validate_integer($agentgid)
-  validate_integer($agentuid)
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,45 @@
+{
+  "name":    "simp-snmpd",
+  "version": "4.1.0",
+  "author":  "simp",
+  "summary": "Manages SNMPD",
+  "license": "Apache-2.0",
+  "source":  "https://github.com/simp/pupmod-simp-snmpd",
+  "project_page": "https://github.com/simp/pupmod-simp-snmpd",
+  "issues_url":   "https://simp-project.atlassian.net",
+  "tags": [ "simp", "snmp", "snmpd" ],
+  "dependencies": [
+    {
+      "name": "simp-common",
+      "version_requirement": ">= 4.2.0"
+    },
+    {
+      "name": "simp-rsync",
+      "version_requirement": ">= 2.0.0"
+    },
+    {
+      "name": "simp-simpcat",
+      "version_requirement": ">= 4.0.0"
+    },
+    {
+      "name": "simp-simplib",
+      "version_requirement": ">= 1.0.0"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "6",
+        "7"
+      ]
+    }
+  ]
+}

--- a/spec/classes/agentx/master/conf_spec.rb
+++ b/spec/classes/agentx/master/conf_spec.rb
@@ -1,8 +1,17 @@
 require 'spec_helper'
 
 describe 'snmpd::agentx::master::conf' do
+  on_supported_os.each do |os, facts|
+    let(:facts) do
+      facts
+    end
 
-  it { should create_class('snmpd::agentx::master::conf') }
-  it { should compile.with_all_deps }
-  it { should create_concat_fragment('snmpd+master.global.agentX') }
+    context "on #{os}" do
+      describe 'with default parameters' do
+        it { should create_class('snmpd::agentx::master::conf') }
+        it { should compile.with_all_deps }
+        it { should create_concat_fragment('snmpd+master.global.agentX') }
+      end
+    end
+  end
 end

--- a/spec/classes/agentx/master/perms_spec.rb
+++ b/spec/classes/agentx/master/perms_spec.rb
@@ -1,8 +1,15 @@
 require 'spec_helper'
 
 describe 'snmpd::agentx::master::perms' do
+  on_supported_os.each do |os, facts|
+    let(:facts) do
+      facts
+    end
 
-  it { should create_class('snmpd::agentx::master::perms') }
-  it { should compile.with_all_deps }
-  it { should create_concat_fragment('snmpd+perms.agentX') }
+    context "on #{os}" do
+      it { should create_class('snmpd::agentx::master::perms') }
+      it { should compile.with_all_deps }
+      it { should create_concat_fragment('snmpd+perms.agentX') }
+    end
+  end
 end

--- a/spec/classes/agentx/sub/conf_spec.rb
+++ b/spec/classes/agentx/sub/conf_spec.rb
@@ -1,8 +1,17 @@
 require 'spec_helper'
 
 describe 'snmpd::agentx::sub::conf' do
+  on_supported_os.each do |os, facts|
+    let(:facts) do
+      facts
+    end
 
-  it { should create_class('snmpd::agentx::sub::conf') }
-  it { should compile.with_all_deps }
-  it { should create_concat_fragment('snmpd+sub.global.agentX') }
+    context "on #{os}" do
+      describe 'with default parameters' do
+        it { should create_class('snmpd::agentx::sub::conf') }
+        it { should compile.with_all_deps }
+        it { should create_concat_fragment('snmpd+sub.global.agentX') }
+      end
+    end
+  end
 end

--- a/spec/classes/authtrapenable_spec.rb
+++ b/spec/classes/authtrapenable_spec.rb
@@ -1,8 +1,17 @@
 require 'spec_helper'
 
 describe 'snmpd::authtrapenable' do
+  on_supported_os.each do |os, facts|
+    let(:facts) do
+      facts
+    end
 
-  it { should create_class('snmpd::authtrapenable') }
-  it { should compile.with_all_deps }
-  it { should contain_concat_fragment('snmpd+all.authtrapenable') }
+    context "on #{os}" do
+      describe 'with default parameters' do
+        it { should create_class('snmpd::authtrapenable') }
+        it { should compile.with_all_deps }
+        it { should contain_concat_fragment('snmpd+all.authtrapenable') }
+      end
+    end
+  end
 end

--- a/spec/classes/diskusage/include_all_disks_spec.rb
+++ b/spec/classes/diskusage/include_all_disks_spec.rb
@@ -2,7 +2,17 @@ require 'spec_helper'
 
 describe 'snmpd::diskusage::include_all_disks' do
 
-  it { should create_class('snmpd::diskusage::include_all_disks') }
-  it { should compile.with_all_deps }
-  it { should create_concat_fragment('snmpd+all.disks') }
+  on_supported_os.each do |os, facts|
+    let(:facts) do
+      facts
+    end
+
+    context "on #{os}" do
+      describe 'with default parameters' do
+        it { should create_class('snmpd::diskusage::include_all_disks') }
+        it { should compile.with_all_deps }
+        it { should create_concat_fragment('snmpd+all.disks') }
+      end
+    end
+  end
 end

--- a/spec/classes/disman/globals_spec.rb
+++ b/spec/classes/disman/globals_spec.rb
@@ -1,8 +1,17 @@
 require 'spec_helper'
 
 describe 'snmpd::disman::globals' do
+  on_supported_os.each do |os, facts|
+    let(:facts) do
+      facts
+    end
 
-  it { should create_class('snmpd::disman::globals') }
-  it { should compile.with_all_deps }
-  it { should contain_concat_fragment('snmpd+disman.globals') }
+    context "on #{os}" do
+      describe 'with default parameters' do
+        it { should create_class('snmpd::disman::globals') }
+        it { should compile.with_all_deps }
+        it { should contain_concat_fragment('snmpd+disman.globals') }
+      end
+    end
+  end
 end

--- a/spec/classes/extension/perl/global_spec.rb
+++ b/spec/classes/extension/perl/global_spec.rb
@@ -1,8 +1,17 @@
 require 'spec_helper'
 
 describe 'snmpd::extension::perl::global' do
+  on_supported_os.each do |os, facts|
+    let(:facts) do
+      facts
+    end
 
-  it { should create_class('snmpd::extension::perl::global') }
-  it { should compile.with_all_deps }
-  it { should contain_concat_fragment('snmpd+ext.perl.global') }
+    context "on #{os}" do
+      describe 'with default parameters' do
+        it { should create_class('snmpd::extension::perl::global') }
+        it { should compile.with_all_deps }
+        it { should contain_concat_fragment('snmpd+ext.perl.global') }
+      end
+    end
+  end
 end

--- a/spec/classes/host_resources_spec.rb
+++ b/spec/classes/host_resources_spec.rb
@@ -1,8 +1,17 @@
 require 'spec_helper'
 
 describe 'snmpd::host_resources' do
+  on_supported_os.each do |os, facts|
+    let(:facts) do
+      facts
+    end
 
-  it { should create_class('snmpd::host_resources') }
-  it { should compile.with_all_deps }
-  it { should create_concat_fragment('snmpd+info.host_resources') }
+    context "on #{os}" do
+      describe 'with default parameters' do
+        it { should create_class('snmpd::host_resources') }
+        it { should compile.with_all_deps }
+        it { should create_concat_fragment('snmpd+info.host_resources') }
+      end
+    end
+  end
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,36 +1,34 @@
 require 'spec_helper'
 
 describe 'snmpd' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts){base_facts.merge({ :interfaces => 'eth0' })}
 
-
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
-
-  it { should create_class('snmpd') }
-  it { should compile.with_all_deps }
-  it { should contain_concat_build('snmpd') }
-  it { should contain_concat_build('snmpd_agentaddress') }
-  it { should create_file('/etc/snmp/snmpd.conf').with({
-      :notify  => ['Service[snmpd]', 'Exec[set_snmp_perms]'],
-      :audit   => 'content',
-      :require => ['Package[net-snmp]', 'Package[net-snmp-libs]']
-    })
-  }
-  it { should contain_package('net-snmp').with_ensure('latest') }
-  it { should contain_package('net-snmp-libs').with_ensure('latest') }
-  it { should create_file('/etc/snmp/snmpd.local.conf').with({
-      :notify  => ['Service[snmpd]', 'Exec[set_snmp_perms]'],
-      :require => ['Package[net-snmp]', 'Package[net-snmp-libs]']
-    })
-  }
-  it { should contain_rsync('snmp_dlmod') }
-  it { should contain_service('snmpd').with({
-      :ensure    => 'running',
-      :enable    => true,
-      :subscribe => 'File[/etc/snmp/snmpd.conf]',
-      :require   => ['Package[net-snmp]', 'Package[net-snmp-libs]']
-    })
-  }
+    context "on #{os}" do
+      describe 'with default parameters' do
+        it { should create_class('snmpd') }
+        it { should compile.with_all_deps }
+        it { should contain_concat_build('snmpd') }
+        it { should contain_concat_build('snmpd_agentaddress') }
+        it { should create_file('/etc/snmp/snmpd.conf').with({
+            :notify  => ['Service[snmpd]', 'Exec[set_snmp_perms]'],
+            :audit   => 'content',
+            :require => ['Package[net-snmp]', 'Package[net-snmp-libs]']
+        })}
+        it { should contain_package('net-snmp').with_ensure('latest') }
+        it { should contain_package('net-snmp-libs').with_ensure('latest') }
+        it { should create_file('/etc/snmp/snmpd.local.conf').with({
+            :notify  => ['Service[snmpd]', 'Exec[set_snmp_perms]'],
+            :require => ['Package[net-snmp]', 'Package[net-snmp-libs]']
+        })}
+        it { should contain_rsync('snmp_dlmod') }
+        it { should contain_service('snmpd').with({
+            :ensure    => 'running',
+            :enable    => true,
+            :subscribe => 'File[/etc/snmp/snmpd.conf]',
+            :require   => ['Package[net-snmp]', 'Package[net-snmp-libs]']
+        })}
+      end
+    end
+  end
 end

--- a/spec/classes/load_spec.rb
+++ b/spec/classes/load_spec.rb
@@ -1,8 +1,17 @@
 require 'spec_helper'
 
 describe 'snmpd::load' do
+  on_supported_os.each do |os, facts|
+    let(:facts) do
+      facts
+    end
 
-  it { should create_class('snmpd::load') }
-  it { should compile.with_all_deps }
-  it { should create_concat_fragment('snmpd+mon.load') }
+    context "on #{os}" do
+      describe 'with default parameters' do
+        it { should create_class('snmpd::load') }
+        it { should compile.with_all_deps }
+        it { should create_concat_fragment('snmpd+mon.load') }
+      end
+    end
+  end
 end

--- a/spec/classes/swap_spec.rb
+++ b/spec/classes/swap_spec.rb
@@ -1,8 +1,17 @@
 require 'spec_helper'
 
 describe 'snmpd::swap' do
+  on_supported_os.each do |os, facts|
+    let(:facts) do
+      facts
+    end
 
-  it { should create_class('snmpd::swap') }
-  it { should compile.with_all_deps }
-  it { should create_concat_fragment('snmpd+swap.load') }
+    context "on #{os}" do
+      describe 'with default parameters' do
+        it { should create_class('snmpd::swap') }
+        it { should compile.with_all_deps }
+        it { should create_concat_fragment('snmpd+swap.load') }
+      end
+    end
+  end
 end

--- a/spec/classes/sysinfo_spec.rb
+++ b/spec/classes/sysinfo_spec.rb
@@ -1,8 +1,17 @@
 require 'spec_helper'
 
 describe 'snmpd::sysinfo' do
+  on_supported_os.each do |os, facts|
+    let(:facts) do
+      facts
+    end
 
-  it { should create_class('snmpd::sysinfo') }
-  it { should compile.with_all_deps }
-  it { should contain_concat_fragment('snmpd+info.system') }
+    context "on #{os}" do
+      describe 'with default parameters' do
+        it { should create_class('snmpd::sysinfo') }
+        it { should compile.with_all_deps }
+        it { should contain_concat_fragment('snmpd+info.system') }
+      end
+    end
+  end
 end

--- a/spec/classes/utils/conf_spec.rb
+++ b/spec/classes/utils/conf_spec.rb
@@ -2,16 +2,20 @@ require 'spec_helper'
 
 describe 'snmpd::utils::conf' do
 
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+  on_supported_os.each do |os, base_facts|
+    let(:facts){base_facts.merge( :interfaces => 'eth0' )}
 
-  it { should create_class('snmpd::utils::conf') }
-  it { should compile.with_all_deps }
-  it { should create_file('/etc/snmp/snmp.conf').with({
-      :content => /defSecurityLevel\sauthPriv/,
-      :notify  => 'Exec[set_snmp_perms]'
-    })
-  }
+    context "on #{os}" do
+      describe 'with default parameters' do
+
+        it { should create_class('snmpd::utils::conf') }
+        it { should compile.with_all_deps }
+        it { should create_file('/etc/snmp/snmp.conf').with({
+            :content => /defSecurityLevel\sauthPriv/,
+            :notify  => 'Exec[set_snmp_perms]'
+          })
+        }
+      end
+    end
+  end
 end

--- a/spec/classes/utils_spec.rb
+++ b/spec/classes/utils_spec.rb
@@ -1,20 +1,29 @@
 require 'spec_helper'
 
 describe 'snmpd::utils' do
+  on_supported_os.each do |os, facts|
+    let(:facts) do
+      facts
+    end
 
-  it { should create_class('snmpd::utils') }
-  it { should compile.with_all_deps }
-  it { should contain_class('rsync') }
-  it { should contain_package('net-snmp-utils') }
-  it { should contain_exec('set_snmp_perms') }
-  it { should create_file('/etc/snmp/snmp.local.conf').with({
-      :notify  => 'Exec[set_snmp_perms]',
-      :require => 'Package[net-snmp-utils]'
-    })
-  }
-  it { should create_file('/usr/local/share/snmp').with({
-      :ensure  => 'directory',
-      :require => 'Package[net-snmp-utils]'
-    })
-  }
+    context "on #{os}" do
+      describe 'with default parameters' do
+        it { should create_class('snmpd::utils') }
+        it { should compile.with_all_deps }
+        it { should contain_class('rsync') }
+        it { should contain_package('net-snmp-utils') }
+        it { should contain_exec('set_snmp_perms') }
+        it { should create_file('/etc/snmp/snmp.local.conf').with({
+            :notify  => 'Exec[set_snmp_perms]',
+            :require => 'Package[net-snmp-utils]'
+          })
+        }
+        it { should create_file('/usr/local/share/snmp').with({
+            :ensure  => 'directory',
+            :require => 'Package[net-snmp-utils]'
+          })
+        }
+      end
+    end
+  end
 end

--- a/spec/defines/agentaddress_spec.rb
+++ b/spec/defines/agentaddress_spec.rb
@@ -2,18 +2,22 @@ require 'spec_helper'
 
 describe 'snmpd::agentaddress' do
 
-  let(:title) {'test'}
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      describe 'with default parameters' do
+        let(:title) {'test'}
+        it { should compile.with_all_deps }
+        it { should contain_class('snmpd') }
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-
-  context 'base' do
-    it { should create_concat_fragment('snmpd_agentaddress+test.agentaddress') }
-    it { should contain_iptables__add_udp_listen('snmpd_test_udp_listen') }
+        context 'base' do
+          it { should create_concat_fragment('snmpd_agentaddress+test.agentaddress') }
+          it { should contain_iptables__add_udp_listen('snmpd_test_udp_listen') }
+        end
+      end
+    end
   end
 end

--- a/spec/defines/communityacl_spec.rb
+++ b/spec/defines/communityacl_spec.rb
@@ -1,21 +1,19 @@
 require 'spec_helper'
 
 describe 'snmpd::communityacl' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts){ base_facts.merge({ :community => 'foo_bar' }) }
 
-  let(:title) {'test_community'}
-  let(:params) {{
-    :community => 'foo_bar'
-  }}
+    context "on #{os}" do
+      let(:title) {'test_community'}
+      let(:params) {{ :community => 'foo_bar' }}
 
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-
-  context 'base' do
-    it { should create_concat_fragment('snmpd+test_community.comm') }
+      context 'base' do
+        it { should create_concat_fragment('snmpd+test_community.comm') }
+      end
+    end
   end
 end

--- a/spec/defines/createuser_spec.rb
+++ b/spec/defines/createuser_spec.rb
@@ -1,18 +1,20 @@
 require 'spec_helper'
 
 describe 'snmpd::createuser' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_user'}
-  let(:params) {{
-    :auth_phrase => 'test_auth_pass',
-    :priv_phrase => 'test_priv_pass'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
-
-  it { should compile.with_all_deps }
-  it { should create_concat_fragment('snmpd+test_user.user') }
-  it { should contain_class('snmpd') }
+    context "on #{os}" do
+      let(:title) {'test_user'}
+      let(:params) {{
+        :auth_phrase => 'test_auth_pass',
+        :priv_phrase => 'test_priv_pass'
+      }}
+      it { should compile.with_all_deps }
+      it { should create_concat_fragment('snmpd+test_user.user') }
+      it { should contain_class('snmpd') }
+    end
+  end
 end

--- a/spec/defines/diskusage/disk_spec.rb
+++ b/spec/defines/diskusage/disk_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_helper'
 
 describe 'snmpd::diskusage::disk' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_disk'}
-  let(:params) {{
-    :disk_path => '/test/disk/path'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_disk'}
+      let(:params) {{
+        :disk_path => '/test/disk/path'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_disk.disks') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_disk.disks') }
+    end
+  end
 end

--- a/spec/defines/disman/monitor_spec.rb
+++ b/spec/defines/disman/monitor_spec.rb
@@ -2,16 +2,20 @@ require 'spec_helper'
 
 describe 'snmpd::disman::monitor' do
 
-  let(:title) {'test_monitor'}
-  let(:params) {{
-    :expression => 'test_expression'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+disman.test_monitor.monitor') }
+    context "on #{os}" do
+      let(:title) {'test_monitor'}
+      let(:params) {{
+        :expression => 'test_expression'
+      }}
+
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+disman.test_monitor.monitor') }
+    end
+  end
 end

--- a/spec/defines/disman/notification_event_spec.rb
+++ b/spec/defines/disman/notification_event_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_helper'
 
 describe 'snmpd::disman::notification_event' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_notification_event'}
-  let(:params) {{
-    :notification => 'Test Notification'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_notification_event'}
+      let(:params) {{
+        :notification => 'Test Notification'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+disman.test_notification_event.ne') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+disman.test_notification_event.ne') }
+    end
+  end
 end

--- a/spec/defines/disman/sched/at_spec.rb
+++ b/spec/defines/disman/sched/at_spec.rb
@@ -2,17 +2,21 @@ require 'spec_helper'
 
 describe 'snmpd::disman::sched::at' do
 
-  let(:title) {'test_at'}
-  let(:params) {{
-    :oid   => '1234567890',
-    :value => 'test_value'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+disman.test_at.at') }
+    context "on #{os}" do
+      let(:title) {'test_at'}
+      let(:params) {{
+        :oid   => '1234567890',
+        :value => 'test_value'
+      }}
+
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+disman.test_at.at') }
+    end
+  end
 end

--- a/spec/defines/disman/sched/cron_spec.rb
+++ b/spec/defines/disman/sched/cron_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::disman::sched::cron' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_cron'}
-  let(:params) {{
-    :oid   => '1234567890',
-    :value => 'test_value'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_cron'}
+      let(:params) {{
+        :oid   => '1234567890',
+        :value => 'test_value'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+disman.test_cron.cron') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+disman.test_cron.cron') }
+    end
+  end
 end

--- a/spec/defines/disman/sched/repeat_spec.rb
+++ b/spec/defines/disman/sched/repeat_spec.rb
@@ -1,19 +1,23 @@
 require 'spec_helper'
 
 describe 'snmpd::disman::sched::repeat' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_repeat'}
-  let(:params) {{
-    :frequency => 'weekly',
-    :oid       => '1234567890',
-    :value     => 'test_value'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+disman.test_repeat.sched') }
+      let(:title) {'test_repeat'}
+      let(:params) {{
+        :frequency => 'weekly',
+        :oid       => '1234567890',
+        :value     => 'test_value'
+      }}
+
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+disman.test_repeat.sched') }
+    end
+  end
 end

--- a/spec/defines/disman/set_event_spec.rb
+++ b/spec/defines/disman/set_event_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::disman::set_event' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_set_event'}
-  let(:params) {{
-    :oid   => '1234567890',
-    :value => 'test_value'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_set_event'}
+      let(:params) {{
+        :oid   => '1234567890',
+        :value => 'test_value'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+disman.test_set_event.setevent') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+disman.test_set_event.setevent') }
+    end
+  end
 end

--- a/spec/defines/dlmod_spec.rb
+++ b/spec/defines/dlmod_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_helper'
 
 describe 'snmpd::dlmod' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_dlmod'}
-  let(:params) {{
-    :path => '/test/path/foo/bar'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_dlmod'}
+      let(:params) {{
+        :path => '/test/path/foo/bar'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should create_concat_fragment('snmpd+test_dlmod.module') }
-  it { should contain_class('snmpd') }
+      it { should compile.with_all_deps }
+      it { should create_concat_fragment('snmpd+test_dlmod.module') }
+      it { should contain_class('snmpd') }
+    end
+  end
 end

--- a/spec/defines/extension/arbitrary_spec.rb
+++ b/spec/defines/extension/arbitrary_spec.rb
@@ -1,19 +1,22 @@
 require 'spec_helper'
 
 describe 'snmpd::extension::arbitrary' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_arbitrary'}
-  let(:params) {{
-    :ext_type => 'exec',
-    :prog     => 'test_prog',
-    :args     => 'foo,bar,baz'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_arbitrary'}
+      let(:params) {{
+        :ext_type => 'exec',
+        :prog     => 'test_prog',
+        :args     => 'foo,bar,baz'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+ext.test_arbitrary.exec') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+ext.test_arbitrary.exec') }
+    end
+  end
 end

--- a/spec/defines/extension/mib_specific_spec.rb
+++ b/spec/defines/extension/mib_specific_spec.rb
@@ -1,19 +1,22 @@
 require 'spec_helper'
 
 describe 'snmpd::extension::mib_specific' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_mib_specific'}
-  let(:params) {{
-    :ext_type => 'pass',
-    :miboid   => '1234567890',
-    :prog     => 'test_program'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_mib_specific'}
+      let(:params) {{
+        :ext_type => 'pass',
+        :miboid   => '1234567890',
+        :prog     => 'test_program'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+ext.test_mib_specific.pass') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+ext.test_mib_specific.pass') }
+    end
+  end
 end

--- a/spec/defines/extension/perl/expression_spec.rb
+++ b/spec/defines/extension/perl/expression_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_helper'
 
 describe 'snmpd::extension::perl::expression' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_expression'}
-  let(:params) {{
-    :expression => 'exec'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_expression'}
+      let(:params) {{
+        :expression => 'exec'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+ext.perl.exp.test_expression') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+ext.perl.exp.test_expression') }
+    end
+  end
 end

--- a/spec/defines/informsink_spec.rb
+++ b/spec/defines/informsink_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::informsink' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_informsink'}
-  let(:params) {{
-    :community => 'test_community',
-    :port      => '12345'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_informsink'}
+      let(:params) {{
+        :community => 'test_community',
+        :port      => '12345'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should create_concat_fragment('snmpd+test_informsink.inform.sink') }
-  it { should contain_class('snmpd') }
+      it { should compile.with_all_deps }
+      it { should create_concat_fragment('snmpd+test_informsink.inform.sink') }
+      it { should contain_class('snmpd') }
+    end
+  end
 end

--- a/spec/defines/inject_handler_spec.rb
+++ b/spec/defines/inject_handler_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::inject_handler' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_inject_handler'}
-  let(:params) {{
-    :handler_type => 'debug',
-    :modulename   => 'test_module'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_inject_handler'}
+      let(:params) {{
+        :handler_type => 'debug',
+        :modulename   => 'test_module'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_inject_handler.debug.inject') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_inject_handler.debug.inject') }
+    end
+  end
 end

--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::interface' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_interface'}
-  let(:params) {{
-    :type  => 'ethernet',
-    :speed => '1000'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_interface'}
+      let(:params) {{
+        :type  => 'ethernet',
+        :speed => '1000'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_interface.iface') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_interface.iface') }
+    end
+  end
 end

--- a/spec/defines/logmatch_spec.rb
+++ b/spec/defines/logmatch_spec.rb
@@ -1,19 +1,22 @@
 require 'spec_helper'
 
 describe 'snmpd::logmatch' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_logmatch'}
-  let(:params) {{
-    :file_path  => '/test/path/foo/bar',
-    :cycle_time => '60',
-    :regex      => '^test*'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_logmatch'}
+      let(:params) {{
+        :file_path  => '/test/path/foo/bar',
+        :cycle_time => '60',
+        :regex      => '^test*'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_logmatch.logmatch') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_logmatch.logmatch') }
+    end
+  end
 end

--- a/spec/defines/monitor_log_file_spec.rb
+++ b/spec/defines/monitor_log_file_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::monitor_log_file' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_monitor_log_file'}
-  let(:params) {{
-    :file_path => '/test/path/foo/bar',
-    :max_size  => '1024'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_monitor_log_file'}
+      let(:params) {{
+        :file_path => '/test/path/foo/bar',
+        :max_size  => '1024'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_monitor_log_file.logmon') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_monitor_log_file.logmon') }
+    end
+  end
 end

--- a/spec/defines/override_spec.rb
+++ b/spec/defines/override_spec.rb
@@ -1,19 +1,22 @@
 require 'spec_helper'
 
 describe 'snmpd::override' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_override'}
-  let(:params) {{
-    :oid     => '1234567890',
-    :or_type => 'foo',
-    :value   => 'bar'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_override'}
+      let(:params) {{
+        :oid     => '1234567890',
+        :or_type => 'foo',
+        :value   => 'bar'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_override_override.other') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_override_override.other') }
+    end
+  end
 end

--- a/spec/defines/procmon/proc_spec.rb
+++ b/spec/defines/procmon/proc_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::procmon::proc' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_proc'}
-  let(:params) {{
-    :max => '90',
-    :min => '50'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_proc'}
+      let(:params) {{
+        :max => '90',
+        :min => '50'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_proc.proc') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_proc.proc') }
+    end
+  end
 end

--- a/spec/defines/procmon/procfix_spec.rb
+++ b/spec/defines/procmon/procfix_spec.rb
@@ -1,18 +1,22 @@
 require 'spec_helper'
 
 describe 'snmpd::procmon::procfix' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_procfix'}
-  let(:params) {{
-    :prog => 'test_program',
-    :args => 'foo,bar,baz'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_procfix.procfix') }
+      let(:title) {'test_procfix'}
+      let(:params) {{
+        :prog => 'test_program',
+        :args => 'foo,bar,baz'
+      }}
+
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_procfix.procfix') }
+    end
+  end
 end

--- a/spec/defines/proxy_spec.rb
+++ b/spec/defines/proxy_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::proxy' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_proxy'}
-  let(:params) {{
-    :host => 'test.example.domain',
-    :oid  => '1234567890'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_proxy'}
+      let(:params) {{
+        :host => 'test.example.domain',
+        :oid  => '1234567890'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_proxy.proxy') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_proxy.proxy') }
+    end
+  end
 end

--- a/spec/defines/smux/smuxpeer_spec.rb
+++ b/spec/defines/smux/smuxpeer_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::smux::smuxpeer' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_smuxpeer'}
-  let(:params) {{
-    :oid  => '1234567890',
-    :pass => 'test_pass'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_smuxpeer'}
+      let(:params) {{
+        :oid  => '1234567890',
+        :pass => 'test_pass'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+peer.test_smuxpeer.smux') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+peer.test_smuxpeer.smux') }
+    end
+  end
 end

--- a/spec/defines/smux/smuxsocket_spec.rb
+++ b/spec/defines/smux/smuxsocket_spec.rb
@@ -1,19 +1,22 @@
 require 'spec_helper'
 
 describe 'snmpd::smux::smuxsocket' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_smuxsocket'}
-  let(:params) {{
-    :ipv4_address  => '1.2.3.4',
-    :allowed_nets  => '1.2.3.4/32'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_smuxsocket'}
+      let(:params) {{
+        :ipv4_address  => '1.2.3.4',
+        :allowed_nets  => '1.2.3.4/32'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+socket.test_smuxsocket.smux') }
-  it { should create_iptables__add_tcp_stateful_listen('smux_test_smuxsocket') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+socket.test_smuxsocket.smux') }
+      it { should create_iptables__add_tcp_stateful_listen('smux_test_smuxsocket') }
+    end
+  end
 end

--- a/spec/defines/trap2sink_spec.rb
+++ b/spec/defines/trap2sink_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::trap2sink' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_trap2sink'}
-  let(:params) {{
-    :community => 'test_community',
-    :port      => '12345'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_trap2sink'}
+      let(:params) {{
+        :community => 'test_community',
+        :port      => '12345'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_trap2sink.trap2.sink') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_trap2sink.trap2.sink') }
+    end
+  end
 end

--- a/spec/defines/trapcommunity_spec.rb
+++ b/spec/defines/trapcommunity_spec.rb
@@ -1,14 +1,17 @@
 require 'spec_helper'
 
 describe 'snmpd::trapcommunity' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_trapcommunity'}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_trapcommunity'}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_trapcommunity.comstr') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_trapcommunity.comstr') }
+    end
+  end
 end

--- a/spec/defines/trapsess_spec.rb
+++ b/spec/defines/trapsess_spec.rb
@@ -1,14 +1,17 @@
 require 'spec_helper'
 
 describe 'snmpd::trapsess' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts
+    end
 
-  let(:title) {'test_trapsess'}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_trapsess'}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_trapsess.trapsess') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_trapsess.trapsess') }
+    end
+  end
 end

--- a/spec/defines/trapsink_spec.rb
+++ b/spec/defines/trapsink_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::trapsink' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts
+    end
 
-  let(:title) {'test_trapsink'}
-  let(:params) {{
-    :community => 'test_community',
-    :port      => '12345'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_trapsink'}
+      let(:params) {{
+        :community => 'test_community',
+        :port      => '12345'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_trapsink.trap.sink') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_trapsink.trap.sink') }
+    end
+  end
 end

--- a/spec/defines/useracl_spec.rb
+++ b/spec/defines/useracl_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_helper'
 
 describe 'snmpd::useracl' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_useracl'}
-  let(:params) {{
-    :user => 'test_user',
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_useracl'}
+      let(:params) {{
+        :user => 'test_user',
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_useracl.auth') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_useracl.auth') }
+    end
+  end
 end

--- a/spec/defines/utils/mibfile_spec.rb
+++ b/spec/defines/utils/mibfile_spec.rb
@@ -1,14 +1,17 @@
 require 'spec_helper'
 
 describe 'snmpd::utils::mibfile' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts
+    end
 
-  let(:title) {'test_mibfile'}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_mibfile'}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should contain_simp_file_line('test_mibfile') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should contain_simp_file_line('test_mibfile') }
+    end
+  end
 end

--- a/spec/defines/v1trapaddress_spec.rb
+++ b/spec/defines/v1trapaddress_spec.rb
@@ -1,14 +1,17 @@
 require 'spec_helper'
 
 describe 'snmpd::v1trapaddress' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts
+    end
 
-  let(:title) {'test_v1trapaddress'}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_v1trapaddress'}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+all.v1trapaddress') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+all.v1trapaddress') }
+    end
+  end
 end

--- a/spec/defines/vacm/access_spec.rb
+++ b/spec/defines/vacm/access_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_helper'
 
 describe 'snmpd::vacm::access' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_access'}
-  let(:params) {{
-    :group => 'test_group'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_access'}
+      let(:params) {{
+        :group => 'test_group'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_access.access') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_access.access') }
+    end
+  end
 end

--- a/spec/defines/vacm/authaccess_spec.rb
+++ b/spec/defines/vacm/authaccess_spec.rb
@@ -1,19 +1,22 @@
 require 'spec_helper'
 
 describe 'snmpd::vacm::authaccess' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_authaccess'}
-  let(:params) {{
-    :types => 'test_types',
-    :group => 'test_group',
-    :view  => 'test_view'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_authaccess'}
+      let(:params) {{
+        :types => 'test_types',
+        :group => 'test_group',
+        :view  => 'test_view'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_authaccess.autha') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_authaccess.autha') }
+    end
+  end
 end

--- a/spec/defines/vacm/authcommunity_spec.rb
+++ b/spec/defines/vacm/authcommunity_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::vacm::authcommunity' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_authcommunity'}
-  let(:params) {{
-    :types     => 'test_types',
-    :community => 'test_community'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_authcommunity'}
+      let(:params) {{
+        :types     => 'test_types',
+        :community => 'test_community'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_authcommunity.authc') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_authcommunity.authc') }
+    end
+  end
 end

--- a/spec/defines/vacm/authgroup_spec.rb
+++ b/spec/defines/vacm/authgroup_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::vacm::authgroup' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_authgroup'}
-  let(:params) {{
-    :types => 'test_types',
-    :group => 'test_group'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_authgroup'}
+      let(:params) {{
+        :types => 'test_types',
+        :group => 'test_group'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_authgroup.authg') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_authgroup.authg') }
+    end
+  end
 end

--- a/spec/defines/vacm/authuser_spec.rb
+++ b/spec/defines/vacm/authuser_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::vacm::authuser' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_authuser'}
-  let(:params) {{
-    :types => 'test_types',
-    :user  => 'test_user'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_authuser'}
+      let(:params) {{
+        :types => 'test_types',
+        :user  => 'test_user'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_authuser.authu') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_authuser.authu') }
+    end
+  end
 end

--- a/spec/defines/vacm/com2sec_spec.rb
+++ b/spec/defines/vacm/com2sec_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::vacm::com2sec' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_com2sec'}
-  let(:params) {{
-    :secname   => 'test_secname',
-    :community => 'test_community'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_com2sec'}
+      let(:params) {{
+        :secname   => 'test_secname',
+        :community => 'test_community'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_com2sec.com2sec') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_com2sec.com2sec') }
+    end
+  end
 end

--- a/spec/defines/vacm/group_spec.rb
+++ b/spec/defines/vacm/group_spec.rb
@@ -1,18 +1,21 @@
 require 'spec_helper'
 
 describe 'snmpd::vacm::group' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_group'}
-  let(:params) {{
-    :group   => 'test_group',
-    :secname => 'test_secname'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_group'}
+      let(:params) {{
+        :group   => 'test_group',
+        :secname => 'test_secname'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_group.group') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_group.group') }
+    end
+  end
 end

--- a/spec/defines/vacm/setaccess_spec.rb
+++ b/spec/defines/vacm/setaccess_spec.rb
@@ -1,23 +1,26 @@
 require 'spec_helper'
 
 describe 'snmpd::vacm::setaccess' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_setaccess'}
-  let(:params) {{
-    :group   => 'test_group',
-    :context => 'test_context',
-    :model   => 'test_model',
-    :level   => 'test_level',
-    :prefix  => 'test_prefix',
-    :view    => 'test_view',
-    :types   => 'test_types'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_setaccess'}
+      let(:params) {{
+        :group   => 'test_group',
+        :context => 'test_context',
+        :model   => 'test_model',
+        :level   => 'test_level',
+        :prefix  => 'test_prefix',
+        :view    => 'test_view',
+        :types   => 'test_types'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_setaccess.autha') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_setaccess.autha') }
+    end
+  end
 end

--- a/spec/defines/vacm/view_spec.rb
+++ b/spec/defines/vacm/view_spec.rb
@@ -1,17 +1,20 @@
 require 'spec_helper'
 
 describe 'snmpd::vacm::access' do
+  on_supported_os.each do |os, base_facts|
+    let(:facts) do
+      base_facts.merge({ :interfaces => 'eth0' })
+    end
 
-  let(:title) {'test_access'}
-  let(:params) {{
-    :group => 'test_group'
-  }}
-  base_facts = {
-    :interfaces => 'eth0'
-  }
-  let(:facts){base_facts}
+    context "on #{os}" do
+      let(:title) {'test_access'}
+      let(:params) {{
+        :group => 'test_group'
+      }}
 
-  it { should compile.with_all_deps }
-  it { should contain_class('snmpd') }
-  it { should create_concat_fragment('snmpd+test_access.access') }
+      it { should compile.with_all_deps }
+      it { should contain_class('snmpd') }
+      it { should create_concat_fragment('snmpd+test_access.access') }
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,8 +2,17 @@ require 'pathname'
 require 'rspec-puppet'
 require 'puppetlabs_spec_helper/module_spec_helper'
 
+require 'simp/rspec-puppet-facts'
+include Simp::RspecPuppetFacts
+
 # RSpec Material
+
+def mod_site_pp(content)
+  File.open(@orig_site_pp,'w'){|f| f.write(content) }
+end
+
 fixture_path = File.expand_path(File.join(__FILE__, '..', 'fixtures'))
+module_name = File.basename(File.expand_path(File.join(__FILE__,'../..')))
 
 # Add fixture lib dirs to LOAD_PATH. Work-around for PUP-3336
 if Puppet.version < "4.0.0"
@@ -22,31 +31,107 @@ default_hiera_config =<<-EOM
 :hierarchy:
   # This is a variable that you can set in your test classes to ensure that the
   # targeted YAML file gets loaded in the fixtures.
-  - "%{spec_title}"
+  - "%{custom_hiera}"
   - "%{module_name}"
   - "default"
 EOM
 
+# This can be used from inside your spec tests to set the testable environment.
+# You can use this to stub out an ENC.
+#
+# Example:
+#
+# context 'in the :foo environment' do
+#   let(:environment){:foo}
+#   ...
+# end
+#
+def set_environment(environment = :production)
+    RSpec.configure { |c| c.default_facts['environment'] = environment.to_s }
+end
+
+# This can be used from inside your spec tests to load custom hieradata within
+# any context.
+#
+# Example:
+#
+# describe 'some::class' do
+#   context 'with version 10' do
+#     let(:hieradata){ "#{class_name}_v10" }
+#     ...
+#   end
+# end
+#
+# Then, create a YAML file at spec/fixtures/hieradata/some__class_v10.yaml.
+#
+# Hiera will use this file as it's base of information stacked on top of
+# 'default.yaml' and <module_name>.yaml per the defaults above.
+#
+# Note: Any colons (:) are replaced with underscores (_) in the class name.
+def set_hieradata(hieradata)
+    RSpec.configure { |c| c.default_facts['custom_hiera'] = hieradata }
+end
+
+
+if not File.directory?(File.join(fixture_path,'hieradata')) then
+  FileUtils.mkdir_p(File.join(fixture_path,'hieradata'))
+end
+
+if not File.directory?(File.join(fixture_path,'modules',module_name)) then
+  FileUtils.mkdir_p(File.join(fixture_path,'modules',module_name))
+end
+
 RSpec.configure do |c|
+  # ENC-style environment facts
+  c.default_facts = {
+#    :fqdn           => 'production.rspec.test.localdomain',
+    :path           => '/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin',
+    :concat_basedir => '/tmp'
+  }
+
   c.mock_framework = :rspec
+  c.mock_with :mocha
 
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')
 
   c.hiera_config = File.join(fixture_path,'hieradata','hiera.yaml')
 
-  c.before(:all) do
-# Add fixture lib dirs to LOAD_PATH. Work-around for PUP-3336
-if Puppet.version < "4.0.0"
-  Dir["#{fixture_path}/modules/*/lib"].entries.each do |lib_dir|
-    $LOAD_PATH << lib_dir
-  end
-end
+  if true
+    # Supress useless backtrace noise
+    # START BKGRND
+    backtrace_exclusion_patterns = [
+      /spec_helper/,
+      /gems/
+    ]
 
+    if c.respond_to?(:backtrace_exclusion_patterns)
+      c.backtrace_exclusion_patterns = backtrace_exclusion_patterns
+    elsif c.respond_to?(:backtrace_clean_patterns)
+      c.backtrace_clean_patterns = backtrace_exclusion_patterns
+    end
+    # END BKGRND
+  end
+
+  # create the default hierarchy file
+  c.before(:all) do
     data = YAML.load(default_hiera_config)
     data[:yaml][:datadir] = File.join(fixture_path, 'hieradata')
+
     File.open(c.hiera_config, 'w') do |f|
       f.write data.to_yaml
+    end
+  end
+
+  c.before(:each) do
+    if defined?(environment)
+      set_environment(environment)
+    end
+
+    if defined?(hieradata)
+      set_hieradata(hieradata.gsub(':','_'))
+    elsif defined?(class_name)
+      set_hieradata(class_name.gsub(':','_'))
     end
   end
 end


### PR DESCRIPTION
Before this commit, common SIMP-related custom functions were been kept
in either `simp-common` or `simp-functions`, and the `concat` function
was provided by the `simp-concat` module.  These functions are now
provides by the `simp-simplib` and `simp-simpcat` modules, respectively.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-601 #comment Migrated `pupmod-simp-snmpd`.
SIMP-604 #comment Updated `pupmod-simp-snmpd`.
