### PR TITLE
(SIMP-667) Normalize common module assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+.*.sw?
+.yardoc
+dist
+/pkg
+/spec/fixtures
+!/spec/hieradata/default.yaml
+!/spec/fixtures/site.pp
+/.rspec_system
+/.vagrant
+/.bundle
+/Gemfile.lock
+/vendor
+/junit
+/log

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,5 +1,4 @@
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
---no-variables_not_enclosed-check
 --no-class_inherits_from_params_class-check
 --no-80chars-check

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,27 @@
 ---
 language: ruby
+sudo: false
 cache: bundler
+before_script:
+  - bundle
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
+script:
+  - bundle exec rake test
+notifications:
+  email: false
 rvm:
-#  - 1.8.7  # bombs out on mime-types
+  - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.1
-script:
-    - 'bundle exec rake validate'
-    - 'bundle exec rake lint'
-    - 'bundle exec rake spec'
-# NOTE: `:environmentpath` was not supported before Puppet 3.5
 env:
   global:
     - STRICT_VARIABLES=yes
     - TRUSTED_NODE_DATA=yes
   matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
     - PUPPET_VERSION="~> 3.5.0"
     - PUPPET_VERSION="~> 3.6.0"
     - PUPPET_VERSION="~> 3.7.0"
@@ -28,7 +31,6 @@ env:
     - PUPPET_VERSION="~> 4.0.0"
     - PUPPET_VERSION="~> 4.1.0"
     - PUPPET_VERSION="~> 4.2.0"
-
 matrix:
   fast_finish: true
   allow_failures:
@@ -39,33 +41,50 @@ matrix:
     - env: PUPPET_VERSION="~> 3.6.0"
     - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
     - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
     - env: PUPPET_VERSION="~> 4.1.0"
     - env: PUPPET_VERSION="~> 4.2.0"
 
   exclude:
   # Ruby 1.8.7
   # - Ruby 1.8.7 & Puppet 4.X is impossibru
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.0.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.2.0"
 
   # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
   # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
   # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
-
-  # Ruby 1.9.3
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
-
-  # Ruby 2.0.0
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
 
   # Ruby 2.1.0
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.1.0
     env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
 
   # Ruby 2.2.1
   - rvm: 2.2.1
     env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.2.1
     env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0"
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,92 @@
+This module has grown over time based on a range of contributions from
+people using it. If you follow these contributing guidelines your patch
+will likely make it into a release a little quicker.
+
+
 ## Contributing
 
-Please refer to the main [SIMP Project Contributing Guide](https://github.com/NationalSecurityAgency/SIMP/blob/master/CONTRIBUTING.md)
-for details on contributing to this project.
+1. Fork the repo.
+
+2. Run the tests. We only take pull requests with passing tests, and
+   it's great to know that you have a clean slate.
+
+3. Add a test for your change. Only refactoring and documentation
+   changes require no new tests. If you are adding functionality
+   or fixing a bug, please add a test.
+
+4. Make the test pass.
+
+5. Push to your fork and submit a pull request.
+
+
+## Dependencies
+
+The testing and development tools have a bunch of dependencies,
+all managed by [Bundler](http://bundler.io/) according to the
+[Puppet support matrix](http://docs.puppetlabs.com/guides/platforms.html#ruby-versions).
+
+By default the tests use a baseline version of Puppet.
+
+If you have Ruby 2.x or want a specific version of Puppet,
+you must set an environment variable such as:
+
+    export PUPPET_VERSION="~> 3.2.0"
+
+Install the dependencies like so...
+
+    bundle install
+
+## Syntax and style
+
+The test suite will run [Puppet Lint](http://puppet-lint.com/) and
+[Puppet Syntax](https://github.com/gds-operations/puppet-syntax) to
+check various syntax and style things. You can run these locally with:
+
+    bundle exec rake lint
+    bundle exec rake syntax
+
+## Running the unit tests
+
+The unit test suite covers most of the code, as mentioned above please
+add tests if you're adding new functionality. If you've not used
+[rspec-puppet](http://rspec-puppet.com/) before then feel free to ask
+about how best to test your new feature. Running the test suite is done
+with:
+
+    bundle exec rake spec
+
+Note also you can run the syntax, style and unit tests in one go with:
+
+    bundle exec rake test
+
+### Automatically run the tests
+
+During development of your puppet module you might want to run your unit
+tests a couple of times. You can use the following command to automate
+running the unit tests on every change made in the manifests folder.
+
+    bundle exec guard
+
+## Integration tests
+
+The unit tests just check the code runs, not that it does exactly what
+we want on a real machine. For that we're using
+[Beaker](https://github.com/puppetlabs/beaker).
+
+Beaker fires up a new virtual machine (using Vagrant) and runs a series of
+simple tests against it after applying the module. You can run our
+Beaker tests with:
+
+    bundle exec rake acceptance
+
+This will use the host described in `spec/acceptance/nodeset/default.yml`
+by default. To run against another host, set the `BEAKER_set` environment
+variable to the name of a host described by a `.yml` file in the
+`nodeset` directory. For example, to run against CentOS 6.4:
+
+    BEAKER_set=centos-64-x64 bundle exec rake acceptance
+
+If you don't want to have to recreate the virtual machine every time you
+can use `BEAKER_destroy=no` and `BEAKER_provision=no`. On the first run you will
+at least need `BEAKER_provision` set to yes (the default). The Vagrantfile
+for the created virtual machines will be in `.vagrant/beaker_vagrant_files`.

--- a/Gemfile
+++ b/Gemfile
@@ -2,38 +2,38 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
-puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  gem 'rake'
+  gem "rake"
   gem 'puppet', puppetversion
-  gem 'rspec', '< 3.2.0'
-  gem 'rspec-puppet'
-  gem 'puppetlabs_spec_helper'
-  gem 'metadata-json-lint'
-  gem 'simp-rspec-puppet-facts'
+  gem "rspec", '< 3.2.0'
+  gem "rspec-puppet"
+  gem "puppetlabs_spec_helper"
+  gem "metadata-json-lint"
+  gem "simp-rspec-puppet-facts"
+
+  # dependency hacks:
+  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
 
   # simp-rake-helpers does not suport puppet 2.7.X
-  # FIXME: simp-rake-helpers should support Puppet 4.X
-  if (!(['2','4'].include?( "#{ENV['PUPPET_VERSION']}".split('.').first)) &&
-      ("#{ENV['PUPPET_VERSION']}" !~ /~> ?(2|4)/ ? true : false) ) &&
+  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
       # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
       # TODO: fix upstream deps (parallel in simp-rake-helpers)
-      !( ENV['TRAVIS'] && RUBY_VERSION.sub(/\.\d+$/,'') == '1.8' )
+      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
     gem 'simp-rake-helpers'
   end
 end
 
 group :development do
-  gem 'travis'
-  gem 'travis-lint'
-  gem 'vagrant-wrapper'
-  gem 'puppet-blacksmith'
-  gem 'guard'
-  gem 'guard-rake'
+  gem "travis"
+  gem "travis-lint"
+  gem "vagrant-wrapper"
+  gem "puppet-blacksmith"
+  gem "guard-rake"
   gem 'pry'
   gem 'pry-doc'
 end
@@ -41,4 +41,12 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
+
+  # 1.0.5 introduces FIPS-first acc tests
+  gem 'simp-beaker-helpers', '>= 1.0.5'
+
+  # dependency hacks:
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
 end

--- a/build/pupmod-snmpd.spec
+++ b/build/pupmod-snmpd.spec
@@ -1,7 +1,7 @@
 Summary: SNMP Puppet Module
 Name: pupmod-snmpd
 Version: 4.1.0
-Release: 4
+Release: 5
 License: Apache License, Version 2.0
 Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
@@ -58,6 +58,9 @@ mkdir -p %{buildroot}/%{prefix}/snmpd
 # Post uninstall stuff
 
 %changelog
+* Thu Feb 18 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.0-5
+- Minor linting fixes
+
 * Mon Nov 09 2015 Chris Tessmer <chris.tessmer@onypoint.com> - 4.1.0-4
 - migration to simplib and simpcat (lib/ only)
 

--- a/manifests/authtrapenable.pp
+++ b/manifests/authtrapenable.pp
@@ -13,6 +13,7 @@
 class snmpd::authtrapenable (
   $enable = false
 ) {
+  validate_bool($enable)
 
   $l_enable = $enable ? {
     true    => '1',
@@ -20,8 +21,6 @@ class snmpd::authtrapenable (
   }
 
   concat_fragment { 'snmpd+all.authtrapenable':
-    content => "authtrapenable $l_enable\n"
+    content => "authtrapenable ${l_enable}\n"
   }
-
-  validate_bool($enable)
 }

--- a/manifests/communityacl.pp
+++ b/manifests/communityacl.pp
@@ -41,10 +41,10 @@ define snmpd::communityacl (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+$name.comm":
-    content => template('snmpd/acl.erb')
-  }
-
   validate_bool($ro)
   validate_bool($ipv6)
+
+  concat_fragment { "snmpd+${name}.comm":
+    content => template('snmpd/acl.erb')
+  }
 }

--- a/manifests/createuser.pp
+++ b/manifests/createuser.pp
@@ -30,11 +30,11 @@ define snmpd::createuser (
 
   if empty($engine_id) {
     $lcontent =
-      "createUser $name $auth_type $auth_phrase $priv_type $priv_phrase\n"
+      "createUser ${name} ${auth_type} ${auth_phrase} ${priv_type} ${priv_phrase}\n"
   }
   else {
     $lcontent =
-      "createUser -e $engine_id $name $auth_type $auth_phrase $priv_type $priv_phrase\n"
+      "createUser -e ${engine_id} ${name} ${auth_type} ${auth_phrase} ${priv_type} ${priv_phrase}\n"
   }
 
   concat_fragment { "snmpd+${name}.user":

--- a/manifests/disman/monitor.pp
+++ b/manifests/disman/monitor.pp
@@ -23,6 +23,6 @@ define snmpd::disman::monitor (
   include 'snmpd'
 
   concat_fragment { "snmpd+disman.${name}.monitor":
-    content => "monitor $options $name $expression\n",
+    content => "monitor ${options} ${name} ${expression}\n",
   }
 }

--- a/manifests/disman/notification_event.pp
+++ b/manifests/disman/notification_event.pp
@@ -22,6 +22,6 @@ define snmpd::disman::notification_event (
   include 'snmpd'
 
   concat_fragment { "snmpd+disman.${name}.ne":
-    content => "notificationEvent $name $notification $::varbinds\n"
+    content => "notificationEvent ${name} ${notification} ${::varbinds}\n"
   }
 }

--- a/manifests/disman/sched/at.pp
+++ b/manifests/disman/sched/at.pp
@@ -34,6 +34,6 @@ define snmpd::disman::sched::at (
   include 'snmpd'
 
   concat_fragment { "snmpd+disman.${name}.at":
-    content => "at $minute $hour $day $month $weekday $oid = $value\n"
+    content => "at ${minute} ${hour} ${day} ${month} ${weekday} ${oid} = ${value}\n"
   }
 }

--- a/manifests/disman/sched/cron.pp
+++ b/manifests/disman/sched/cron.pp
@@ -31,6 +31,6 @@ define snmpd::disman::sched::cron (
   include 'snmpd'
 
   concat_fragment { "snmpd+disman.${name}.cron":
-    content => "cron $minute $hour $day $month $weekday $oid = $value\n"
+    content => "cron ${minute} ${hour} ${day} ${month} ${weekday} ${oid} = ${value}\n"
   }
 }

--- a/manifests/disman/sched/repeat.pp
+++ b/manifests/disman/sched/repeat.pp
@@ -25,7 +25,7 @@ define snmpd::disman::sched::repeat (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+disman.$name.sched":
-    content => "repeat $frequency $oid = $value\n"
+  concat_fragment { "snmpd+disman.${name}.sched":
+    content => "repeat ${frequency} ${oid} = ${value}\n"
   }
 }

--- a/manifests/dlmod.pp
+++ b/manifests/dlmod.pp
@@ -21,6 +21,6 @@ define snmpd::dlmod (
   include 'snmpd'
 
   concat_fragment { "snmpd+${name}.module":
-    content => "dlmod $name $path\n",
+    content => "dlmod ${name} ${path}\n",
   }
 }

--- a/manifests/extension/perl/expression.pp
+++ b/manifests/extension/perl/expression.pp
@@ -19,6 +19,6 @@ define snmpd::extension::perl::expression (
   include 'snmpd'
 
   concat_fragment { "snmpd+ext.perl.exp.${name}":
-    content => "perl $expression\n"
+    content => "perl ${expression}\n"
   }
 }

--- a/manifests/informsink.pp
+++ b/manifests/informsink.pp
@@ -25,6 +25,6 @@ define snmpd::informsink (
   include 'snmpd'
 
   concat_fragment { "snmpd+${name}.inform.sink":
-    content => "informsink $name $community $port\n"
+    content => "informsink ${name} ${community} ${port}\n"
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,7 +86,7 @@ class snmpd (
 
   concat_build { 'snmpd_agentaddress':
     clean_whitespace => 'all',
-    target           => "$l_fragdir/agentaddress.all",
+    target           => "${l_fragdir}/agentaddress.all",
     parent_build     => 'snmpd',
     file_delimiter   => ',',
     quiet            => true

--- a/manifests/inject_handler.pp
+++ b/manifests/inject_handler.pp
@@ -21,7 +21,7 @@ define snmpd::inject_handler (
   include 'snmpd'
 
   concat_fragment { "snmpd+${name}.${handler_type}.inject":
-    content => "injectHandler $handler_type $modulename\n"
+    content => "injectHandler ${handler_type} ${modulename}\n"
   }
 
   validate_array_member($handler_type, [

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -23,6 +23,6 @@ define snmpd::interface (
   include 'snmpd'
 
   concat_fragment { "snmpd+${name}.iface":
-    content => "interface $name $type $speed\n",
+    content => "interface ${name} ${type} ${speed}\n",
   }
 }

--- a/manifests/load.pp
+++ b/manifests/load.pp
@@ -18,6 +18,6 @@ class snmpd::load (
   $max15 = ''
 ) {
   concat_fragment { 'snmpd+mon.load':
-    content => "load $max1 $max5 $max15\n"
+    content => "load ${max1} ${max5} ${max15}\n"
   }
 }

--- a/manifests/logmatch.pp
+++ b/manifests/logmatch.pp
@@ -25,6 +25,6 @@ define snmpd::logmatch (
   include 'snmpd'
 
   concat_fragment { "snmpd+${name}.logmatch":
-    content => "logmatch $name $file_path $cycle_time $regex\n"
+    content => "logmatch ${name} ${file_path} ${cycle_time} ${regex}\n"
   }
 }

--- a/manifests/monitor_log_file.pp
+++ b/manifests/monitor_log_file.pp
@@ -24,6 +24,6 @@ define snmpd::monitor_log_file (
   include 'snmpd'
 
   concat_fragment { "snmpd+${name}.logmon":
-    content => "file $file_path $max_size\n"
+    content => "file ${file_path} ${max_size}\n"
   }
 }

--- a/manifests/procmon/procfix.pp
+++ b/manifests/procmon/procfix.pp
@@ -21,6 +21,6 @@ define snmpd::procmon::procfix (
   include 'snmpd'
 
   concat_fragment { "snmpd+${name}.procfix":
-    content => "procfix $name $prog $args\n"
+    content => "procfix ${name} ${prog} ${args}\n"
   }
 }

--- a/manifests/smux/smuxpeer.pp
+++ b/manifests/smux/smuxpeer.pp
@@ -18,6 +18,6 @@ define snmpd::smux::smuxpeer (
   include 'snmpd'
 
   concat_fragment { "snmpd+peer.${name}.smux":
-    content => "smuxpeer $oid $pass\n"
+    content => "smuxpeer ${oid} ${pass}\n"
   }
 }

--- a/manifests/smux/smuxsocket.pp
+++ b/manifests/smux/smuxsocket.pp
@@ -17,16 +17,16 @@ define snmpd::smux::smuxsocket (
 ) {
   include 'snmpd'
 
+  validate_net_list($allowed_nets)
+
   concat_fragment { "snmpd+socket.${name}.smux":
-    content => "smuxsocket $ipv4_address\n"
+    content => "smuxsocket ${ipv4_address}\n"
   }
 
   if defined('iptables') and defined(Class['iptables']) {
-    iptables::add_tcp_stateful_listen { "smux_$name":
+    iptables::add_tcp_stateful_listen { "smux_${name}":
       client_nets => $allowed_nets,
       dports      => '199'
     }
   }
-
-  validate_net_list($allowed_nets)
 }

--- a/manifests/swap.pp
+++ b/manifests/swap.pp
@@ -16,7 +16,7 @@ class snmpd::swap (
   $min
 ) {
   concat_fragment { 'snmpd+swap.load':
-    content => "swap $min\n"
+    content => "swap ${min}\n"
   }
 
   validate_integer($min)

--- a/manifests/trap2sink.pp
+++ b/manifests/trap2sink.pp
@@ -20,13 +20,13 @@ define snmpd::trap2sink (
   $community = '',
   $port = ''
 ) {
+  if !empty($port) {
+    validate_port($port)
+  }
+
   include 'snmpd'
 
   concat_fragment { "snmpd+${name}.trap2.sink":
-    content => "trap2sink $name $community $port\n"
-  }
-
-  if !empty($port) {
-    validate_port($port)
+    content => "trap2sink ${name} ${community} ${port}\n"
   }
 }

--- a/manifests/trapcommunity.pp
+++ b/manifests/trapcommunity.pp
@@ -15,6 +15,6 @@ define snmpd::trapcommunity {
   include 'snmpd'
 
   concat_fragment { "snmpd+${name}.comstr":
-    content => "trapcommunity $name\n"
+    content => "trapcommunity ${name}\n"
   }
 }

--- a/manifests/trapsess.pp
+++ b/manifests/trapsess.pp
@@ -18,6 +18,6 @@ define snmpd::trapsess (
   include 'snmpd'
 
   concat_fragment { "snmpd+${name}.trapsess":
-    content => "trapsess $snmpcmd_args $name\n"
+    content => "trapsess ${snmpcmd_args} ${name}\n"
   }
 }

--- a/manifests/trapsink.pp
+++ b/manifests/trapsink.pp
@@ -20,13 +20,13 @@ define snmpd::trapsink (
   $community = '',
   $port = ''
 ) {
+  if !empty($port) {
+    validate_port($port)
+  }
+
   include 'snmpd'
 
   concat_fragment { "snmpd+${name}.trap.sink":
-    content => "trapsink $name $community $port\n"
-  }
-
-  if !empty($port) {
-    validate_port($port)
+    content => "trapsink ${name} ${community} ${port}\n"
   }
 }

--- a/manifests/utils/mibfile.pp
+++ b/manifests/utils/mibfile.pp
@@ -18,7 +18,7 @@ define snmpd::utils::mibfile {
 
   simp_file_line { $name:
     path   => '/etc/snmp/snmp.local.conf',
-    line   => "mibfile $name",
+    line   => "mibfile ${name}",
     notify => File['/etc/snmp/snmp.local.conf']
   }
 }

--- a/manifests/v1trapaddress.pp
+++ b/manifests/v1trapaddress.pp
@@ -15,6 +15,6 @@ define snmpd::v1trapaddress {
   include 'snmpd'
 
   concat_fragment { 'snmpd+all.v1trapaddress':
-    content => "v1trapaddress $name\n"
+    content => "v1trapaddress ${name}\n"
   }
 }

--- a/manifests/vacm/access.pp
+++ b/manifests/vacm/access.pp
@@ -30,7 +30,7 @@ define snmpd::vacm::access (
 
   concat_fragment { "snmpd+${name}.access":
     content =>
-      "access $group $context $sec_model $level $prefix $read $write none\n"
+      "access ${group} ${context} ${sec_model} ${level} ${prefix} ${read} ${write} none\n"
   }
 
   validate_array_member($sec_model, [

--- a/manifests/vacm/group.pp
+++ b/manifests/vacm/group.pp
@@ -29,7 +29,7 @@ define snmpd::vacm::group (
   include 'snmpd'
 
   concat_fragment { "snmpd+${name}.group":
-    content => "group $group $sec_model $secname\n",
+    content => "group ${group} ${sec_model} ${secname}\n",
   }
 
   validate_array_member($sec_model, [

--- a/manifests/vacm/setaccess.pp
+++ b/manifests/vacm/setaccess.pp
@@ -24,6 +24,6 @@ define snmpd::vacm::setaccess (
   include 'snmpd'
 
   concat_fragment { "snmpd+${name}.autha":
-    content => "setaccess $group $context $model $level $prefix $view $types\n"
+    content => "setaccess ${group} ${context} ${model} ${level} ${prefix} ${view} ${types}\n"
   }
 }

--- a/manifests/vacm/view.pp
+++ b/manifests/vacm/view.pp
@@ -24,12 +24,12 @@ define snmpd::vacm::view (
 ) {
   if empty($mask) {
     concat_fragment { "snmpd+${name}.view":
-      content => "view $vname $v_type $oid\n"
+      content => "view ${vname} ${v_type} ${oid}\n"
     }
   }
   else {
     concat_fragment { "snmpd+${name}.view":
-      content => "view $vname $v_type $oid $mask\n",
+      content => "view ${vname} ${v_type} ${oid} ${mask}\n",
     }
   }
 }

--- a/spec/classes/agentx/master/conf_spec.rb
+++ b/spec/classes/agentx/master/conf_spec.rb
@@ -8,9 +8,9 @@ describe 'snmpd::agentx::master::conf' do
 
     context "on #{os}" do
       describe 'with default parameters' do
-        it { should create_class('snmpd::agentx::master::conf') }
-        it { should compile.with_all_deps }
-        it { should create_concat_fragment('snmpd+master.global.agentX') }
+        it { is_expected.to create_class('snmpd::agentx::master::conf') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_concat_fragment('snmpd+master.global.agentX') }
       end
     end
   end

--- a/spec/classes/agentx/master/perms_spec.rb
+++ b/spec/classes/agentx/master/perms_spec.rb
@@ -7,9 +7,9 @@ describe 'snmpd::agentx::master::perms' do
     end
 
     context "on #{os}" do
-      it { should create_class('snmpd::agentx::master::perms') }
-      it { should compile.with_all_deps }
-      it { should create_concat_fragment('snmpd+perms.agentX') }
+      it { is_expected.to create_class('snmpd::agentx::master::perms') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to create_concat_fragment('snmpd+perms.agentX') }
     end
   end
 end

--- a/spec/classes/agentx/sub/conf_spec.rb
+++ b/spec/classes/agentx/sub/conf_spec.rb
@@ -8,9 +8,9 @@ describe 'snmpd::agentx::sub::conf' do
 
     context "on #{os}" do
       describe 'with default parameters' do
-        it { should create_class('snmpd::agentx::sub::conf') }
-        it { should compile.with_all_deps }
-        it { should create_concat_fragment('snmpd+sub.global.agentX') }
+        it { is_expected.to create_class('snmpd::agentx::sub::conf') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_concat_fragment('snmpd+sub.global.agentX') }
       end
     end
   end

--- a/spec/classes/authtrapenable_spec.rb
+++ b/spec/classes/authtrapenable_spec.rb
@@ -8,9 +8,9 @@ describe 'snmpd::authtrapenable' do
 
     context "on #{os}" do
       describe 'with default parameters' do
-        it { should create_class('snmpd::authtrapenable') }
-        it { should compile.with_all_deps }
-        it { should contain_concat_fragment('snmpd+all.authtrapenable') }
+        it { is_expected.to create_class('snmpd::authtrapenable') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat_fragment('snmpd+all.authtrapenable') }
       end
     end
   end

--- a/spec/classes/diskusage/include_all_disks_spec.rb
+++ b/spec/classes/diskusage/include_all_disks_spec.rb
@@ -9,9 +9,9 @@ describe 'snmpd::diskusage::include_all_disks' do
 
     context "on #{os}" do
       describe 'with default parameters' do
-        it { should create_class('snmpd::diskusage::include_all_disks') }
-        it { should compile.with_all_deps }
-        it { should create_concat_fragment('snmpd+all.disks') }
+        it { is_expected.to create_class('snmpd::diskusage::include_all_disks') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_concat_fragment('snmpd+all.disks') }
       end
     end
   end

--- a/spec/classes/disman/globals_spec.rb
+++ b/spec/classes/disman/globals_spec.rb
@@ -8,9 +8,9 @@ describe 'snmpd::disman::globals' do
 
     context "on #{os}" do
       describe 'with default parameters' do
-        it { should create_class('snmpd::disman::globals') }
-        it { should compile.with_all_deps }
-        it { should contain_concat_fragment('snmpd+disman.globals') }
+        it { is_expected.to create_class('snmpd::disman::globals') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat_fragment('snmpd+disman.globals') }
       end
     end
   end

--- a/spec/classes/extension/perl/global_spec.rb
+++ b/spec/classes/extension/perl/global_spec.rb
@@ -8,9 +8,9 @@ describe 'snmpd::extension::perl::global' do
 
     context "on #{os}" do
       describe 'with default parameters' do
-        it { should create_class('snmpd::extension::perl::global') }
-        it { should compile.with_all_deps }
-        it { should contain_concat_fragment('snmpd+ext.perl.global') }
+        it { is_expected.to create_class('snmpd::extension::perl::global') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat_fragment('snmpd+ext.perl.global') }
       end
     end
   end

--- a/spec/classes/host_resources_spec.rb
+++ b/spec/classes/host_resources_spec.rb
@@ -8,9 +8,9 @@ describe 'snmpd::host_resources' do
 
     context "on #{os}" do
       describe 'with default parameters' do
-        it { should create_class('snmpd::host_resources') }
-        it { should compile.with_all_deps }
-        it { should create_concat_fragment('snmpd+info.host_resources') }
+        it { is_expected.to create_class('snmpd::host_resources') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_concat_fragment('snmpd+info.host_resources') }
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,23 +6,23 @@ describe 'snmpd' do
 
     context "on #{os}" do
       describe 'with default parameters' do
-        it { should create_class('snmpd') }
-        it { should compile.with_all_deps }
-        it { should contain_concat_build('snmpd') }
-        it { should contain_concat_build('snmpd_agentaddress') }
-        it { should create_file('/etc/snmp/snmpd.conf').with({
+        it { is_expected.to create_class('snmpd') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat_build('snmpd') }
+        it { is_expected.to contain_concat_build('snmpd_agentaddress') }
+        it { is_expected.to create_file('/etc/snmp/snmpd.conf').with({
             :notify  => ['Service[snmpd]', 'Exec[set_snmp_perms]'],
             :audit   => 'content',
             :require => ['Package[net-snmp]', 'Package[net-snmp-libs]']
         })}
-        it { should contain_package('net-snmp').with_ensure('latest') }
-        it { should contain_package('net-snmp-libs').with_ensure('latest') }
-        it { should create_file('/etc/snmp/snmpd.local.conf').with({
+        it { is_expected.to contain_package('net-snmp').with_ensure('latest') }
+        it { is_expected.to contain_package('net-snmp-libs').with_ensure('latest') }
+        it { is_expected.to create_file('/etc/snmp/snmpd.local.conf').with({
             :notify  => ['Service[snmpd]', 'Exec[set_snmp_perms]'],
             :require => ['Package[net-snmp]', 'Package[net-snmp-libs]']
         })}
-        it { should contain_rsync('snmp_dlmod') }
-        it { should contain_service('snmpd').with({
+        it { is_expected.to contain_rsync('snmp_dlmod') }
+        it { is_expected.to contain_service('snmpd').with({
             :ensure    => 'running',
             :enable    => true,
             :subscribe => 'File[/etc/snmp/snmpd.conf]',

--- a/spec/classes/load_spec.rb
+++ b/spec/classes/load_spec.rb
@@ -8,9 +8,9 @@ describe 'snmpd::load' do
 
     context "on #{os}" do
       describe 'with default parameters' do
-        it { should create_class('snmpd::load') }
-        it { should compile.with_all_deps }
-        it { should create_concat_fragment('snmpd+mon.load') }
+        it { is_expected.to create_class('snmpd::load') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_concat_fragment('snmpd+mon.load') }
       end
     end
   end

--- a/spec/classes/swap_spec.rb
+++ b/spec/classes/swap_spec.rb
@@ -8,9 +8,9 @@ describe 'snmpd::swap' do
 
     context "on #{os}" do
       describe 'with default parameters' do
-        it { should create_class('snmpd::swap') }
-        it { should compile.with_all_deps }
-        it { should create_concat_fragment('snmpd+swap.load') }
+        it { is_expected.to create_class('snmpd::swap') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_concat_fragment('snmpd+swap.load') }
       end
     end
   end

--- a/spec/classes/sysinfo_spec.rb
+++ b/spec/classes/sysinfo_spec.rb
@@ -8,9 +8,9 @@ describe 'snmpd::sysinfo' do
 
     context "on #{os}" do
       describe 'with default parameters' do
-        it { should create_class('snmpd::sysinfo') }
-        it { should compile.with_all_deps }
-        it { should contain_concat_fragment('snmpd+info.system') }
+        it { is_expected.to create_class('snmpd::sysinfo') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_concat_fragment('snmpd+info.system') }
       end
     end
   end

--- a/spec/classes/utils/conf_spec.rb
+++ b/spec/classes/utils/conf_spec.rb
@@ -8,9 +8,9 @@ describe 'snmpd::utils::conf' do
     context "on #{os}" do
       describe 'with default parameters' do
 
-        it { should create_class('snmpd::utils::conf') }
-        it { should compile.with_all_deps }
-        it { should create_file('/etc/snmp/snmp.conf').with({
+        it { is_expected.to create_class('snmpd::utils::conf') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to create_file('/etc/snmp/snmp.conf').with({
             :content => /defSecurityLevel\sauthPriv/,
             :notify  => 'Exec[set_snmp_perms]'
           })

--- a/spec/classes/utils_spec.rb
+++ b/spec/classes/utils_spec.rb
@@ -8,17 +8,17 @@ describe 'snmpd::utils' do
 
     context "on #{os}" do
       describe 'with default parameters' do
-        it { should create_class('snmpd::utils') }
-        it { should compile.with_all_deps }
-        it { should contain_class('rsync') }
-        it { should contain_package('net-snmp-utils') }
-        it { should contain_exec('set_snmp_perms') }
-        it { should create_file('/etc/snmp/snmp.local.conf').with({
+        it { is_expected.to create_class('snmpd::utils') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('rsync') }
+        it { is_expected.to contain_package('net-snmp-utils') }
+        it { is_expected.to contain_exec('set_snmp_perms') }
+        it { is_expected.to create_file('/etc/snmp/snmp.local.conf').with({
             :notify  => 'Exec[set_snmp_perms]',
             :require => 'Package[net-snmp-utils]'
           })
         }
-        it { should create_file('/usr/local/share/snmp').with({
+        it { is_expected.to create_file('/usr/local/share/snmp').with({
             :ensure  => 'directory',
             :require => 'Package[net-snmp-utils]'
           })

--- a/spec/defines/agentaddress_spec.rb
+++ b/spec/defines/agentaddress_spec.rb
@@ -10,12 +10,12 @@ describe 'snmpd::agentaddress' do
     context "on #{os}" do
       describe 'with default parameters' do
         let(:title) {'test'}
-        it { should compile.with_all_deps }
-        it { should contain_class('snmpd') }
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('snmpd') }
 
         context 'base' do
-          it { should create_concat_fragment('snmpd_agentaddress+test.agentaddress') }
-          it { should contain_iptables__add_udp_listen('snmpd_test_udp_listen') }
+          it { is_expected.to create_concat_fragment('snmpd_agentaddress+test.agentaddress') }
+          it { is_expected.to contain_iptables__add_udp_listen('snmpd_test_udp_listen') }
         end
       end
     end

--- a/spec/defines/communityacl_spec.rb
+++ b/spec/defines/communityacl_spec.rb
@@ -8,11 +8,11 @@ describe 'snmpd::communityacl' do
       let(:title) {'test_community'}
       let(:params) {{ :community => 'foo_bar' }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
 
       context 'base' do
-        it { should create_concat_fragment('snmpd+test_community.comm') }
+        it { is_expected.to create_concat_fragment('snmpd+test_community.comm') }
       end
     end
   end

--- a/spec/defines/createuser_spec.rb
+++ b/spec/defines/createuser_spec.rb
@@ -12,9 +12,9 @@ describe 'snmpd::createuser' do
         :auth_phrase => 'test_auth_pass',
         :priv_phrase => 'test_priv_pass'
       }}
-      it { should compile.with_all_deps }
-      it { should create_concat_fragment('snmpd+test_user.user') }
-      it { should contain_class('snmpd') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to create_concat_fragment('snmpd+test_user.user') }
+      it { is_expected.to contain_class('snmpd') }
     end
   end
 end

--- a/spec/defines/diskusage/disk_spec.rb
+++ b/spec/defines/diskusage/disk_spec.rb
@@ -12,9 +12,9 @@ describe 'snmpd::diskusage::disk' do
         :disk_path => '/test/disk/path'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_disk.disks') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_disk.disks') }
     end
   end
 end

--- a/spec/defines/disman/monitor_spec.rb
+++ b/spec/defines/disman/monitor_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::disman::monitor' do
         :expression => 'test_expression'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+disman.test_monitor.monitor') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+disman.test_monitor.monitor') }
     end
   end
 end

--- a/spec/defines/disman/notification_event_spec.rb
+++ b/spec/defines/disman/notification_event_spec.rb
@@ -12,9 +12,9 @@ describe 'snmpd::disman::notification_event' do
         :notification => 'Test Notification'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+disman.test_notification_event.ne') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+disman.test_notification_event.ne') }
     end
   end
 end

--- a/spec/defines/disman/sched/at_spec.rb
+++ b/spec/defines/disman/sched/at_spec.rb
@@ -14,9 +14,9 @@ describe 'snmpd::disman::sched::at' do
         :value => 'test_value'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+disman.test_at.at') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+disman.test_at.at') }
     end
   end
 end

--- a/spec/defines/disman/sched/cron_spec.rb
+++ b/spec/defines/disman/sched/cron_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::disman::sched::cron' do
         :value => 'test_value'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+disman.test_cron.cron') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+disman.test_cron.cron') }
     end
   end
 end

--- a/spec/defines/disman/sched/repeat_spec.rb
+++ b/spec/defines/disman/sched/repeat_spec.rb
@@ -15,9 +15,9 @@ describe 'snmpd::disman::sched::repeat' do
         :value     => 'test_value'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+disman.test_repeat.sched') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+disman.test_repeat.sched') }
     end
   end
 end

--- a/spec/defines/disman/set_event_spec.rb
+++ b/spec/defines/disman/set_event_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::disman::set_event' do
         :value => 'test_value'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+disman.test_set_event.setevent') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+disman.test_set_event.setevent') }
     end
   end
 end

--- a/spec/defines/dlmod_spec.rb
+++ b/spec/defines/dlmod_spec.rb
@@ -12,9 +12,9 @@ describe 'snmpd::dlmod' do
         :path => '/test/path/foo/bar'
       }}
 
-      it { should compile.with_all_deps }
-      it { should create_concat_fragment('snmpd+test_dlmod.module') }
-      it { should contain_class('snmpd') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to create_concat_fragment('snmpd+test_dlmod.module') }
+      it { is_expected.to contain_class('snmpd') }
     end
   end
 end

--- a/spec/defines/extension/arbitrary_spec.rb
+++ b/spec/defines/extension/arbitrary_spec.rb
@@ -14,9 +14,9 @@ describe 'snmpd::extension::arbitrary' do
         :args     => 'foo,bar,baz'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+ext.test_arbitrary.exec') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+ext.test_arbitrary.exec') }
     end
   end
 end

--- a/spec/defines/extension/mib_specific_spec.rb
+++ b/spec/defines/extension/mib_specific_spec.rb
@@ -14,9 +14,9 @@ describe 'snmpd::extension::mib_specific' do
         :prog     => 'test_program'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+ext.test_mib_specific.pass') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+ext.test_mib_specific.pass') }
     end
   end
 end

--- a/spec/defines/extension/perl/expression_spec.rb
+++ b/spec/defines/extension/perl/expression_spec.rb
@@ -12,9 +12,9 @@ describe 'snmpd::extension::perl::expression' do
         :expression => 'exec'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+ext.perl.exp.test_expression') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+ext.perl.exp.test_expression') }
     end
   end
 end

--- a/spec/defines/informsink_spec.rb
+++ b/spec/defines/informsink_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::informsink' do
         :port      => '12345'
       }}
 
-      it { should compile.with_all_deps }
-      it { should create_concat_fragment('snmpd+test_informsink.inform.sink') }
-      it { should contain_class('snmpd') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to create_concat_fragment('snmpd+test_informsink.inform.sink') }
+      it { is_expected.to contain_class('snmpd') }
     end
   end
 end

--- a/spec/defines/inject_handler_spec.rb
+++ b/spec/defines/inject_handler_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::inject_handler' do
         :modulename   => 'test_module'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_inject_handler.debug.inject') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_inject_handler.debug.inject') }
     end
   end
 end

--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::interface' do
         :speed => '1000'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_interface.iface') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_interface.iface') }
     end
   end
 end

--- a/spec/defines/logmatch_spec.rb
+++ b/spec/defines/logmatch_spec.rb
@@ -14,9 +14,9 @@ describe 'snmpd::logmatch' do
         :regex      => '^test*'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_logmatch.logmatch') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_logmatch.logmatch') }
     end
   end
 end

--- a/spec/defines/monitor_log_file_spec.rb
+++ b/spec/defines/monitor_log_file_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::monitor_log_file' do
         :max_size  => '1024'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_monitor_log_file.logmon') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_monitor_log_file.logmon') }
     end
   end
 end

--- a/spec/defines/override_spec.rb
+++ b/spec/defines/override_spec.rb
@@ -14,9 +14,9 @@ describe 'snmpd::override' do
         :value   => 'bar'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_override_override.other') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_override_override.other') }
     end
   end
 end

--- a/spec/defines/procmon/proc_spec.rb
+++ b/spec/defines/procmon/proc_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::procmon::proc' do
         :min => '50'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_proc.proc') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_proc.proc') }
     end
   end
 end

--- a/spec/defines/procmon/procfix_spec.rb
+++ b/spec/defines/procmon/procfix_spec.rb
@@ -14,9 +14,9 @@ describe 'snmpd::procmon::procfix' do
         :args => 'foo,bar,baz'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_procfix.procfix') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_procfix.procfix') }
     end
   end
 end

--- a/spec/defines/proxy_spec.rb
+++ b/spec/defines/proxy_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::proxy' do
         :oid  => '1234567890'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_proxy.proxy') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_proxy.proxy') }
     end
   end
 end

--- a/spec/defines/smux/smuxpeer_spec.rb
+++ b/spec/defines/smux/smuxpeer_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::smux::smuxpeer' do
         :pass => 'test_pass'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+peer.test_smuxpeer.smux') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+peer.test_smuxpeer.smux') }
     end
   end
 end

--- a/spec/defines/smux/smuxsocket_spec.rb
+++ b/spec/defines/smux/smuxsocket_spec.rb
@@ -13,10 +13,10 @@ describe 'snmpd::smux::smuxsocket' do
         :allowed_nets  => '1.2.3.4/32'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+socket.test_smuxsocket.smux') }
-      it { should create_iptables__add_tcp_stateful_listen('smux_test_smuxsocket') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+socket.test_smuxsocket.smux') }
+      it { is_expected.to create_iptables__add_tcp_stateful_listen('smux_test_smuxsocket') }
     end
   end
 end

--- a/spec/defines/trap2sink_spec.rb
+++ b/spec/defines/trap2sink_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::trap2sink' do
         :port      => '12345'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_trap2sink.trap2.sink') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_trap2sink.trap2.sink') }
     end
   end
 end

--- a/spec/defines/trapcommunity_spec.rb
+++ b/spec/defines/trapcommunity_spec.rb
@@ -9,9 +9,9 @@ describe 'snmpd::trapcommunity' do
     context "on #{os}" do
       let(:title) {'test_trapcommunity'}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_trapcommunity.comstr') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_trapcommunity.comstr') }
     end
   end
 end

--- a/spec/defines/trapsess_spec.rb
+++ b/spec/defines/trapsess_spec.rb
@@ -9,9 +9,9 @@ describe 'snmpd::trapsess' do
     context "on #{os}" do
       let(:title) {'test_trapsess'}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_trapsess.trapsess') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_trapsess.trapsess') }
     end
   end
 end

--- a/spec/defines/trapsink_spec.rb
+++ b/spec/defines/trapsink_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::trapsink' do
         :port      => '12345'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_trapsink.trap.sink') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_trapsink.trap.sink') }
     end
   end
 end

--- a/spec/defines/useracl_spec.rb
+++ b/spec/defines/useracl_spec.rb
@@ -12,9 +12,9 @@ describe 'snmpd::useracl' do
         :user => 'test_user',
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_useracl.auth') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_useracl.auth') }
     end
   end
 end

--- a/spec/defines/utils/mibfile_spec.rb
+++ b/spec/defines/utils/mibfile_spec.rb
@@ -9,9 +9,9 @@ describe 'snmpd::utils::mibfile' do
     context "on #{os}" do
       let(:title) {'test_mibfile'}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should contain_simp_file_line('test_mibfile') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to contain_simp_file_line('test_mibfile') }
     end
   end
 end

--- a/spec/defines/v1trapaddress_spec.rb
+++ b/spec/defines/v1trapaddress_spec.rb
@@ -9,9 +9,9 @@ describe 'snmpd::v1trapaddress' do
     context "on #{os}" do
       let(:title) {'test_v1trapaddress'}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+all.v1trapaddress') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+all.v1trapaddress') }
     end
   end
 end

--- a/spec/defines/vacm/access_spec.rb
+++ b/spec/defines/vacm/access_spec.rb
@@ -12,9 +12,9 @@ describe 'snmpd::vacm::access' do
         :group => 'test_group'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_access.access') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_access.access') }
     end
   end
 end

--- a/spec/defines/vacm/authaccess_spec.rb
+++ b/spec/defines/vacm/authaccess_spec.rb
@@ -14,9 +14,9 @@ describe 'snmpd::vacm::authaccess' do
         :view  => 'test_view'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_authaccess.autha') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_authaccess.autha') }
     end
   end
 end

--- a/spec/defines/vacm/authcommunity_spec.rb
+++ b/spec/defines/vacm/authcommunity_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::vacm::authcommunity' do
         :community => 'test_community'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_authcommunity.authc') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_authcommunity.authc') }
     end
   end
 end

--- a/spec/defines/vacm/authgroup_spec.rb
+++ b/spec/defines/vacm/authgroup_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::vacm::authgroup' do
         :group => 'test_group'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_authgroup.authg') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_authgroup.authg') }
     end
   end
 end

--- a/spec/defines/vacm/authuser_spec.rb
+++ b/spec/defines/vacm/authuser_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::vacm::authuser' do
         :user  => 'test_user'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_authuser.authu') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_authuser.authu') }
     end
   end
 end

--- a/spec/defines/vacm/com2sec_spec.rb
+++ b/spec/defines/vacm/com2sec_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::vacm::com2sec' do
         :community => 'test_community'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_com2sec.com2sec') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_com2sec.com2sec') }
     end
   end
 end

--- a/spec/defines/vacm/group_spec.rb
+++ b/spec/defines/vacm/group_spec.rb
@@ -13,9 +13,9 @@ describe 'snmpd::vacm::group' do
         :secname => 'test_secname'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_group.group') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_group.group') }
     end
   end
 end

--- a/spec/defines/vacm/setaccess_spec.rb
+++ b/spec/defines/vacm/setaccess_spec.rb
@@ -18,9 +18,9 @@ describe 'snmpd::vacm::setaccess' do
         :types   => 'test_types'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_setaccess.autha') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_setaccess.autha') }
     end
   end
 end

--- a/spec/defines/vacm/view_spec.rb
+++ b/spec/defines/vacm/view_spec.rb
@@ -12,9 +12,9 @@ describe 'snmpd::vacm::access' do
         :group => 'test_group'
       }}
 
-      it { should compile.with_all_deps }
-      it { should contain_class('snmpd') }
-      it { should create_concat_fragment('snmpd+test_access.access') }
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to contain_class('snmpd') }
+      it { is_expected.to create_concat_fragment('snmpd+test_access.access') }
     end
   end
 end


### PR DESCRIPTION
This commit synchronizes all common static module assets with current SIMP
module standards.

Also:
- fixed linting errors
- updated rspec tests to the new `expect` syntax
- moved validations and includes to the top of each class
- created .puppet-lint.rc, .travis.yml, .gitignore
- bumped RPM versin up to 4.1.0-5

SIMP-667 #comment updated `pupmod-simp-snmpd`
SIMP-755 #close #comment normalized common module assets
