### PR TITLE
(SIMP-1450) Update to use new 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
+- Updated to use the version of 'simpcat' that does not conflict with
+  'puppetlabs/concat'.
+
 * Thu Feb 18 2016 Chris Tessmer <chris.tessmer@onyxpoint.com> - 4.1.0-5
 - Minor linting fixes
 

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,5 @@
 Requires: pupmod-simp-rsync >= 2.0.0-0
-Requires: pupmod-simp-simpcat >= 2.0.0-0
+Requires: pupmod-simp-simpcat >= 6.0.0-0
 Requires: pupmod-simp-simplib >= 1.0.0-0
 Requires: simp-rsync >= 2.0.0-0
 Obsoletes: pupmod-snmpd-test >= 0.0.1

--- a/manifests/agentaddress.pp
+++ b/manifests/agentaddress.pp
@@ -36,7 +36,7 @@ define snmpd::agentaddress (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd_agentaddress+${name}.agentaddress":
+  simpcat_fragment { "snmpd_agentaddress+${name}.agentaddress":
     content => template('snmpd/agentaddress.erb'),
   }
 

--- a/manifests/agentx/master/conf.pp
+++ b/manifests/agentx/master/conf.pp
@@ -19,7 +19,7 @@ class snmpd::agentx::master::conf (
   $agentx_timeout = '',
   $agentx_retries = ''
 ) {
-  concat_fragment { 'snmpd+master.global.agentX':
+  simpcat_fragment { 'snmpd+master.global.agentX':
     content => template('snmpd/agentX.erb')
   }
 

--- a/manifests/agentx/master/perms.pp
+++ b/manifests/agentx/master/perms.pp
@@ -22,7 +22,7 @@ class snmpd::agentx::master::perms (
   $group = ''
 ) {
 
-  concat_fragment { 'snmpd+perms.agentX':
+  simpcat_fragment { 'snmpd+perms.agentX':
     content => template('snmpd/agentX_perms.erb')
   }
 }

--- a/manifests/agentx/sub/conf.pp
+++ b/manifests/agentx/sub/conf.pp
@@ -19,7 +19,7 @@ class snmpd::agentx::sub::conf (
   $agentx_timeout = '',
   $agentx_retries = ''
 ) {
-  concat_fragment { 'snmpd+sub.global.agentX':
+  simpcat_fragment { 'snmpd+sub.global.agentX':
     content => template('snmpd/agentX.erb')
   }
 

--- a/manifests/authtrapenable.pp
+++ b/manifests/authtrapenable.pp
@@ -20,7 +20,7 @@ class snmpd::authtrapenable (
     default => '2'
   }
 
-  concat_fragment { 'snmpd+all.authtrapenable':
+  simpcat_fragment { 'snmpd+all.authtrapenable':
     content => "authtrapenable ${l_enable}\n"
   }
 }

--- a/manifests/communityacl.pp
+++ b/manifests/communityacl.pp
@@ -44,7 +44,7 @@ define snmpd::communityacl (
   validate_bool($ro)
   validate_bool($ipv6)
 
-  concat_fragment { "snmpd+${name}.comm":
+  simpcat_fragment { "snmpd+${name}.comm":
     content => template('snmpd/acl.erb')
   }
 }

--- a/manifests/createuser.pp
+++ b/manifests/createuser.pp
@@ -37,7 +37,7 @@ define snmpd::createuser (
       "createUser -e ${engine_id} ${name} ${auth_type} ${auth_phrase} ${priv_type} ${priv_phrase}\n"
   }
 
-  concat_fragment { "snmpd+${name}.user":
+  simpcat_fragment { "snmpd+${name}.user":
     content => $lcontent
   }
 }

--- a/manifests/diskusage/disk.pp
+++ b/manifests/diskusage/disk.pp
@@ -27,7 +27,7 @@ define snmpd::diskusage::disk (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.disks":
+  simpcat_fragment { "snmpd+${name}.disks":
     content => template('snmpd/disk.erb')
   }
 }

--- a/manifests/diskusage/include_all_disks.pp
+++ b/manifests/diskusage/include_all_disks.pp
@@ -16,7 +16,7 @@
 class snmpd::diskusage::include_all_disks (
   $minpercent
 ) {
-  concat_fragment { 'snmpd+all.disks':
+  simpcat_fragment { 'snmpd+all.disks':
     content => "includeAllDisks ${minpercent}%\n"
   }
 

--- a/manifests/disman/globals.pp
+++ b/manifests/disman/globals.pp
@@ -23,7 +23,7 @@ class snmpd::disman::globals (
   $link_up_down_notifications = '',
   $default_monitors = ''
 ) {
-  concat_fragment { 'snmpd+disman.globals':
+  simpcat_fragment { 'snmpd+disman.globals':
     content => template('snmpd/disman_globals.erb')
   }
 

--- a/manifests/disman/monitor.pp
+++ b/manifests/disman/monitor.pp
@@ -22,7 +22,7 @@ define snmpd::disman::monitor (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+disman.${name}.monitor":
+  simpcat_fragment { "snmpd+disman.${name}.monitor":
     content => "monitor ${options} ${name} ${expression}\n",
   }
 }

--- a/manifests/disman/notification_event.pp
+++ b/manifests/disman/notification_event.pp
@@ -21,7 +21,7 @@ define snmpd::disman::notification_event (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+disman.${name}.ne":
+  simpcat_fragment { "snmpd+disman.${name}.ne":
     content => "notificationEvent ${name} ${notification} ${::varbinds}\n"
   }
 }

--- a/manifests/disman/sched/at.pp
+++ b/manifests/disman/sched/at.pp
@@ -33,7 +33,7 @@ define snmpd::disman::sched::at (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+disman.${name}.at":
+  simpcat_fragment { "snmpd+disman.${name}.at":
     content => "at ${minute} ${hour} ${day} ${month} ${weekday} ${oid} = ${value}\n"
   }
 }

--- a/manifests/disman/sched/cron.pp
+++ b/manifests/disman/sched/cron.pp
@@ -30,7 +30,7 @@ define snmpd::disman::sched::cron (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+disman.${name}.cron":
+  simpcat_fragment { "snmpd+disman.${name}.cron":
     content => "cron ${minute} ${hour} ${day} ${month} ${weekday} ${oid} = ${value}\n"
   }
 }

--- a/manifests/disman/sched/repeat.pp
+++ b/manifests/disman/sched/repeat.pp
@@ -25,7 +25,7 @@ define snmpd::disman::sched::repeat (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+disman.${name}.sched":
+  simpcat_fragment { "snmpd+disman.${name}.sched":
     content => "repeat ${frequency} ${oid} = ${value}\n"
   }
 }

--- a/manifests/disman/set_event.pp
+++ b/manifests/disman/set_event.pp
@@ -23,7 +23,7 @@ define snmpd::disman::set_event (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+disman.${name}.setevent":
+  simpcat_fragment { "snmpd+disman.${name}.setevent":
     content =>
       inline_template("setEvent <%= @name %> <% if @dash_i then -%>-I <% end -%><%= @oid %> = <%= @value %>\n")
   }

--- a/manifests/dlmod.pp
+++ b/manifests/dlmod.pp
@@ -20,7 +20,7 @@ define snmpd::dlmod (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.module":
+  simpcat_fragment { "snmpd+${name}.module":
     content => "dlmod ${name} ${path}\n",
   }
 }

--- a/manifests/extension/arbitrary.pp
+++ b/manifests/extension/arbitrary.pp
@@ -32,7 +32,7 @@ define snmpd::extension::arbitrary (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+ext.${name}.${ext_type}":
+  simpcat_fragment { "snmpd+ext.${name}.${ext_type}":
     content => template('snmpd/arbitrary_ext.erb')
   }
 

--- a/manifests/extension/mib_specific.pp
+++ b/manifests/extension/mib_specific.pp
@@ -26,7 +26,7 @@ define snmpd::extension::mib_specific (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+ext.${name}.${ext_type}":
+  simpcat_fragment { "snmpd+ext.${name}.${ext_type}":
     content => template('snmpd/mib_specific_ext.erb')
   }
 

--- a/manifests/extension/perl/expression.pp
+++ b/manifests/extension/perl/expression.pp
@@ -18,7 +18,7 @@ define snmpd::extension::perl::expression (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+ext.perl.exp.${name}":
+  simpcat_fragment { "snmpd+ext.perl.exp.${name}":
     content => "perl ${expression}\n"
   }
 }

--- a/manifests/extension/perl/global.pp
+++ b/manifests/extension/perl/global.pp
@@ -17,7 +17,7 @@ class snmpd::extension::perl::global (
   $disable_perl = '',
   $perl_init_file = ''
 ) {
-  concat_fragment { 'snmpd+ext.perl.global':
+  simpcat_fragment { 'snmpd+ext.perl.global':
     content => template('snmpd/perl_global.erb')
   }
 }

--- a/manifests/host_resources.pp
+++ b/manifests/host_resources.pp
@@ -17,7 +17,7 @@ class snmpd::host_resources (
   $skip_NFS_in_host_resources = '',
   $storage_use_NFS = ''
 ) {
-  concat_fragment { 'snmpd+info.host_resources':
+  simpcat_fragment { 'snmpd+info.host_resources':
     content => template('snmpd/host_resources.erb')
   }
 }

--- a/manifests/informsink.pp
+++ b/manifests/informsink.pp
@@ -24,7 +24,7 @@ define snmpd::informsink (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.inform.sink":
+  simpcat_fragment { "snmpd+${name}.inform.sink":
     content => "informsink ${name} ${community} ${port}\n"
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,10 +38,10 @@ class snmpd (
   validate_integer($agentgid)
   validate_integer($agentuid)
 
-  $l_fragdir = fragmentdir('snmpd')
-  $l_outdir = concat_output('snmpd')
+  $l_fragdir = simpcat_fragmentdir('snmpd')
+  $l_outdir = simpcat_output('snmpd')
 
-  concat_build { 'snmpd':
+  simpcat_build { 'snmpd':
     target => '/etc/snmp/snmpd.conf',
     order  => [
         '*.all',
@@ -84,7 +84,7 @@ class snmpd (
     notify => File['/etc/snmp/snmpd.conf']
   }
 
-  concat_build { 'snmpd_agentaddress':
+  simpcat_build { 'snmpd_agentaddress':
     clean_whitespace => 'all',
     target           => "${l_fragdir}/agentaddress.all",
     parent_build     => 'snmpd',
@@ -157,7 +157,7 @@ class snmpd (
     pattern => 'ALL'
   }
 
-  concat_fragment { 'snmpd+main.conf':
+  simpcat_fragment { 'snmpd+main.conf':
     content => template('snmpd/main.conf.erb')
   }
 

--- a/manifests/inject_handler.pp
+++ b/manifests/inject_handler.pp
@@ -20,7 +20,7 @@ define snmpd::inject_handler (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.${handler_type}.inject":
+  simpcat_fragment { "snmpd+${name}.${handler_type}.inject":
     content => "injectHandler ${handler_type} ${modulename}\n"
   }
 

--- a/manifests/interface.pp
+++ b/manifests/interface.pp
@@ -22,7 +22,7 @@ define snmpd::interface (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.iface":
+  simpcat_fragment { "snmpd+${name}.iface":
     content => "interface ${name} ${type} ${speed}\n",
   }
 }

--- a/manifests/load.pp
+++ b/manifests/load.pp
@@ -17,7 +17,7 @@ class snmpd::load (
   $max5 = '',
   $max15 = ''
 ) {
-  concat_fragment { 'snmpd+mon.load':
+  simpcat_fragment { 'snmpd+mon.load':
     content => "load ${max1} ${max5} ${max15}\n"
   }
 }

--- a/manifests/logmatch.pp
+++ b/manifests/logmatch.pp
@@ -24,7 +24,7 @@ define snmpd::logmatch (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.logmatch":
+  simpcat_fragment { "snmpd+${name}.logmatch":
     content => "logmatch ${name} ${file_path} ${cycle_time} ${regex}\n"
   }
 }

--- a/manifests/monitor_log_file.pp
+++ b/manifests/monitor_log_file.pp
@@ -23,7 +23,7 @@ define snmpd::monitor_log_file (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.logmon":
+  simpcat_fragment { "snmpd+${name}.logmon":
     content => "file ${file_path} ${max_size}\n"
   }
 }

--- a/manifests/override.pp
+++ b/manifests/override.pp
@@ -26,7 +26,7 @@ define snmpd::override (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}_override.other":
+  simpcat_fragment { "snmpd+${name}_override.other":
     content =>
       inline_template("override <% if @rw then %>-rw <% end %><%= @oid %> <%= @or_type %> <%= @value %>\n")
   }

--- a/manifests/procmon/proc.pp
+++ b/manifests/procmon/proc.pp
@@ -20,7 +20,7 @@ define snmpd::procmon::proc (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.proc":
+  simpcat_fragment { "snmpd+${name}.proc":
     content => template('snmpd/proc.erb')
   }
 }

--- a/manifests/procmon/procfix.pp
+++ b/manifests/procmon/procfix.pp
@@ -20,7 +20,7 @@ define snmpd::procmon::procfix (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.procfix":
+  simpcat_fragment { "snmpd+${name}.procfix":
     content => "procfix ${name} ${prog} ${args}\n"
   }
 }

--- a/manifests/proxy.pp
+++ b/manifests/proxy.pp
@@ -23,7 +23,7 @@ define snmpd::proxy (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.proxy":
+  simpcat_fragment { "snmpd+${name}.proxy":
     content => template('snmpd/proxy.erb')
   }
 }

--- a/manifests/smux/smuxpeer.pp
+++ b/manifests/smux/smuxpeer.pp
@@ -17,7 +17,7 @@ define snmpd::smux::smuxpeer (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+peer.${name}.smux":
+  simpcat_fragment { "snmpd+peer.${name}.smux":
     content => "smuxpeer ${oid} ${pass}\n"
   }
 }

--- a/manifests/smux/smuxsocket.pp
+++ b/manifests/smux/smuxsocket.pp
@@ -19,7 +19,7 @@ define snmpd::smux::smuxsocket (
 
   validate_net_list($allowed_nets)
 
-  concat_fragment { "snmpd+socket.${name}.smux":
+  simpcat_fragment { "snmpd+socket.${name}.smux":
     content => "smuxsocket ${ipv4_address}\n"
   }
 

--- a/manifests/swap.pp
+++ b/manifests/swap.pp
@@ -15,7 +15,7 @@
 class snmpd::swap (
   $min
 ) {
-  concat_fragment { 'snmpd+swap.load':
+  simpcat_fragment { 'snmpd+swap.load':
     content => "swap ${min}\n"
   }
 

--- a/manifests/sysinfo.pp
+++ b/manifests/sysinfo.pp
@@ -23,7 +23,7 @@ class snmpd::sysinfo (
   $sys_descr = '',
   $sys_object_id = ''
 ) {
-  concat_fragment { 'snmpd+info.system':
+  simpcat_fragment { 'snmpd+info.system':
     content => template('snmpd/sysinfo.erb')
   }
 

--- a/manifests/trap2sink.pp
+++ b/manifests/trap2sink.pp
@@ -26,7 +26,7 @@ define snmpd::trap2sink (
 
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.trap2.sink":
+  simpcat_fragment { "snmpd+${name}.trap2.sink":
     content => "trap2sink ${name} ${community} ${port}\n"
   }
 }

--- a/manifests/trapcommunity.pp
+++ b/manifests/trapcommunity.pp
@@ -14,7 +14,7 @@
 define snmpd::trapcommunity {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.comstr":
+  simpcat_fragment { "snmpd+${name}.comstr":
     content => "trapcommunity ${name}\n"
   }
 }

--- a/manifests/trapsess.pp
+++ b/manifests/trapsess.pp
@@ -17,7 +17,7 @@ define snmpd::trapsess (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.trapsess":
+  simpcat_fragment { "snmpd+${name}.trapsess":
     content => "trapsess ${snmpcmd_args} ${name}\n"
   }
 }

--- a/manifests/trapsink.pp
+++ b/manifests/trapsink.pp
@@ -26,7 +26,7 @@ define snmpd::trapsink (
 
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.trap.sink":
+  simpcat_fragment { "snmpd+${name}.trap.sink":
     content => "trapsink ${name} ${community} ${port}\n"
   }
 }

--- a/manifests/useracl.pp
+++ b/manifests/useracl.pp
@@ -33,7 +33,7 @@ define snmpd::useracl (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.auth":
+  simpcat_fragment { "snmpd+${name}.auth":
     content => template('snmpd/acl.erb')
   }
 

--- a/manifests/v1trapaddress.pp
+++ b/manifests/v1trapaddress.pp
@@ -14,7 +14,7 @@
 define snmpd::v1trapaddress {
   include 'snmpd'
 
-  concat_fragment { 'snmpd+all.v1trapaddress':
+  simpcat_fragment { 'snmpd+all.v1trapaddress':
     content => "v1trapaddress ${name}\n"
   }
 }

--- a/manifests/vacm/access.pp
+++ b/manifests/vacm/access.pp
@@ -28,7 +28,7 @@ define snmpd::vacm::access (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.access":
+  simpcat_fragment { "snmpd+${name}.access":
     content =>
       "access ${group} ${context} ${sec_model} ${level} ${prefix} ${read} ${write} none\n"
   }

--- a/manifests/vacm/authaccess.pp
+++ b/manifests/vacm/authaccess.pp
@@ -25,7 +25,7 @@ define snmpd::vacm::authaccess (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.autha":
+  simpcat_fragment { "snmpd+${name}.autha":
     content => template('snmpd/authaccess.erb')
   }
 }

--- a/manifests/vacm/authcommunity.pp
+++ b/manifests/vacm/authcommunity.pp
@@ -23,7 +23,7 @@ define snmpd::vacm::authcommunity (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.authc":
+  simpcat_fragment { "snmpd+${name}.authc":
     content => template('snmpd/authview.erb')
   }
 }

--- a/manifests/vacm/authgroup.pp
+++ b/manifests/vacm/authgroup.pp
@@ -25,7 +25,7 @@ define snmpd::vacm::authgroup (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.authg":
+  simpcat_fragment { "snmpd+${name}.authg":
     content => template('snmpd/authview.erb')
   }
 

--- a/manifests/vacm/authuser.pp
+++ b/manifests/vacm/authuser.pp
@@ -25,7 +25,7 @@ define snmpd::vacm::authuser (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.authu":
+  simpcat_fragment { "snmpd+${name}.authu":
     content => template('snmpd/authview.erb')
   }
 }

--- a/manifests/vacm/com2sec.pp
+++ b/manifests/vacm/com2sec.pp
@@ -37,7 +37,7 @@ define snmpd::vacm::com2sec (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.com2sec":
+  simpcat_fragment { "snmpd+${name}.com2sec":
     content => template('snmpd/com2sec.erb')
   }
 

--- a/manifests/vacm/group.pp
+++ b/manifests/vacm/group.pp
@@ -28,7 +28,7 @@ define snmpd::vacm::group (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.group":
+  simpcat_fragment { "snmpd+${name}.group":
     content => "group ${group} ${sec_model} ${secname}\n",
   }
 

--- a/manifests/vacm/setaccess.pp
+++ b/manifests/vacm/setaccess.pp
@@ -23,7 +23,7 @@ define snmpd::vacm::setaccess (
 ) {
   include 'snmpd'
 
-  concat_fragment { "snmpd+${name}.autha":
+  simpcat_fragment { "snmpd+${name}.autha":
     content => "setaccess ${group} ${context} ${model} ${level} ${prefix} ${view} ${types}\n"
   }
 }

--- a/manifests/vacm/view.pp
+++ b/manifests/vacm/view.pp
@@ -23,12 +23,12 @@ define snmpd::vacm::view (
   $mask = ''
 ) {
   if empty($mask) {
-    concat_fragment { "snmpd+${name}.view":
+    simpcat_fragment { "snmpd+${name}.view":
       content => "view ${vname} ${v_type} ${oid}\n"
     }
   }
   else {
-    concat_fragment { "snmpd+${name}.view":
+    simpcat_fragment { "snmpd+${name}.view":
       content => "view ${vname} ${v_type} ${oid} ${mask}\n",
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-snmpd",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "author":  "simp",
   "summary": "Manages SNMPD",
   "license": "Apache-2.0",
@@ -15,7 +15,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/classes/agentx/master/conf_spec.rb
+++ b/spec/classes/agentx/master/conf_spec.rb
@@ -10,7 +10,7 @@ describe 'snmpd::agentx::master::conf' do
       describe 'with default parameters' do
         it { is_expected.to create_class('snmpd::agentx::master::conf') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment('snmpd+master.global.agentX') }
+        it { is_expected.to create_simpcat_fragment('snmpd+master.global.agentX') }
       end
     end
   end

--- a/spec/classes/agentx/master/perms_spec.rb
+++ b/spec/classes/agentx/master/perms_spec.rb
@@ -9,7 +9,7 @@ describe 'snmpd::agentx::master::perms' do
     context "on #{os}" do
       it { is_expected.to create_class('snmpd::agentx::master::perms') }
       it { is_expected.to compile.with_all_deps }
-      it { is_expected.to create_concat_fragment('snmpd+perms.agentX') }
+      it { is_expected.to create_simpcat_fragment('snmpd+perms.agentX') }
     end
   end
 end

--- a/spec/classes/agentx/sub/conf_spec.rb
+++ b/spec/classes/agentx/sub/conf_spec.rb
@@ -10,7 +10,7 @@ describe 'snmpd::agentx::sub::conf' do
       describe 'with default parameters' do
         it { is_expected.to create_class('snmpd::agentx::sub::conf') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment('snmpd+sub.global.agentX') }
+        it { is_expected.to create_simpcat_fragment('snmpd+sub.global.agentX') }
       end
     end
   end

--- a/spec/classes/authtrapenable_spec.rb
+++ b/spec/classes/authtrapenable_spec.rb
@@ -10,7 +10,7 @@ describe 'snmpd::authtrapenable' do
       describe 'with default parameters' do
         it { is_expected.to create_class('snmpd::authtrapenable') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat_fragment('snmpd+all.authtrapenable') }
+        it { is_expected.to contain_simpcat_fragment('snmpd+all.authtrapenable') }
       end
     end
   end

--- a/spec/classes/diskusage/include_all_disks_spec.rb
+++ b/spec/classes/diskusage/include_all_disks_spec.rb
@@ -11,7 +11,7 @@ describe 'snmpd::diskusage::include_all_disks' do
       describe 'with default parameters' do
         it { is_expected.to create_class('snmpd::diskusage::include_all_disks') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment('snmpd+all.disks') }
+        it { is_expected.to create_simpcat_fragment('snmpd+all.disks') }
       end
     end
   end

--- a/spec/classes/disman/globals_spec.rb
+++ b/spec/classes/disman/globals_spec.rb
@@ -10,7 +10,7 @@ describe 'snmpd::disman::globals' do
       describe 'with default parameters' do
         it { is_expected.to create_class('snmpd::disman::globals') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat_fragment('snmpd+disman.globals') }
+        it { is_expected.to contain_simpcat_fragment('snmpd+disman.globals') }
       end
     end
   end

--- a/spec/classes/extension/perl/global_spec.rb
+++ b/spec/classes/extension/perl/global_spec.rb
@@ -10,7 +10,7 @@ describe 'snmpd::extension::perl::global' do
       describe 'with default parameters' do
         it { is_expected.to create_class('snmpd::extension::perl::global') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat_fragment('snmpd+ext.perl.global') }
+        it { is_expected.to contain_simpcat_fragment('snmpd+ext.perl.global') }
       end
     end
   end

--- a/spec/classes/host_resources_spec.rb
+++ b/spec/classes/host_resources_spec.rb
@@ -10,7 +10,7 @@ describe 'snmpd::host_resources' do
       describe 'with default parameters' do
         it { is_expected.to create_class('snmpd::host_resources') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment('snmpd+info.host_resources') }
+        it { is_expected.to create_simpcat_fragment('snmpd+info.host_resources') }
       end
     end
   end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -8,8 +8,8 @@ describe 'snmpd' do
       describe 'with default parameters' do
         it { is_expected.to create_class('snmpd') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat_build('snmpd') }
-        it { is_expected.to contain_concat_build('snmpd_agentaddress') }
+        it { is_expected.to contain_simpcat_build('snmpd') }
+        it { is_expected.to contain_simpcat_build('snmpd_agentaddress') }
         it { is_expected.to create_file('/etc/snmp/snmpd.conf').with({
             :notify  => ['Service[snmpd]', 'Exec[set_snmp_perms]'],
             :audit   => 'content',

--- a/spec/classes/load_spec.rb
+++ b/spec/classes/load_spec.rb
@@ -10,7 +10,7 @@ describe 'snmpd::load' do
       describe 'with default parameters' do
         it { is_expected.to create_class('snmpd::load') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment('snmpd+mon.load') }
+        it { is_expected.to create_simpcat_fragment('snmpd+mon.load') }
       end
     end
   end

--- a/spec/classes/swap_spec.rb
+++ b/spec/classes/swap_spec.rb
@@ -10,7 +10,7 @@ describe 'snmpd::swap' do
       describe 'with default parameters' do
         it { is_expected.to create_class('snmpd::swap') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to create_concat_fragment('snmpd+swap.load') }
+        it { is_expected.to create_simpcat_fragment('snmpd+swap.load') }
       end
     end
   end

--- a/spec/classes/sysinfo_spec.rb
+++ b/spec/classes/sysinfo_spec.rb
@@ -10,7 +10,7 @@ describe 'snmpd::sysinfo' do
       describe 'with default parameters' do
         it { is_expected.to create_class('snmpd::sysinfo') }
         it { is_expected.to compile.with_all_deps }
-        it { is_expected.to contain_concat_fragment('snmpd+info.system') }
+        it { is_expected.to contain_simpcat_fragment('snmpd+info.system') }
       end
     end
   end

--- a/spec/defines/agentaddress_spec.rb
+++ b/spec/defines/agentaddress_spec.rb
@@ -14,7 +14,7 @@ describe 'snmpd::agentaddress' do
         it { is_expected.to contain_class('snmpd') }
 
         context 'base' do
-          it { is_expected.to create_concat_fragment('snmpd_agentaddress+test.agentaddress') }
+          it { is_expected.to create_simpcat_fragment('snmpd_agentaddress+test.agentaddress') }
           it { is_expected.to contain_iptables__add_udp_listen('snmpd_test_udp_listen') }
         end
       end

--- a/spec/defines/communityacl_spec.rb
+++ b/spec/defines/communityacl_spec.rb
@@ -12,7 +12,7 @@ describe 'snmpd::communityacl' do
       it { is_expected.to contain_class('snmpd') }
 
       context 'base' do
-        it { is_expected.to create_concat_fragment('snmpd+test_community.comm') }
+        it { is_expected.to create_simpcat_fragment('snmpd+test_community.comm') }
       end
     end
   end

--- a/spec/defines/createuser_spec.rb
+++ b/spec/defines/createuser_spec.rb
@@ -13,7 +13,7 @@ describe 'snmpd::createuser' do
         :priv_phrase => 'test_priv_pass'
       }}
       it { is_expected.to compile.with_all_deps }
-      it { is_expected.to create_concat_fragment('snmpd+test_user.user') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_user.user') }
       it { is_expected.to contain_class('snmpd') }
     end
   end

--- a/spec/defines/diskusage/disk_spec.rb
+++ b/spec/defines/diskusage/disk_spec.rb
@@ -14,7 +14,7 @@ describe 'snmpd::diskusage::disk' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_disk.disks') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_disk.disks') }
     end
   end
 end

--- a/spec/defines/disman/monitor_spec.rb
+++ b/spec/defines/disman/monitor_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::disman::monitor' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+disman.test_monitor.monitor') }
+      it { is_expected.to create_simpcat_fragment('snmpd+disman.test_monitor.monitor') }
     end
   end
 end

--- a/spec/defines/disman/notification_event_spec.rb
+++ b/spec/defines/disman/notification_event_spec.rb
@@ -14,7 +14,7 @@ describe 'snmpd::disman::notification_event' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+disman.test_notification_event.ne') }
+      it { is_expected.to create_simpcat_fragment('snmpd+disman.test_notification_event.ne') }
     end
   end
 end

--- a/spec/defines/disman/sched/at_spec.rb
+++ b/spec/defines/disman/sched/at_spec.rb
@@ -16,7 +16,7 @@ describe 'snmpd::disman::sched::at' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+disman.test_at.at') }
+      it { is_expected.to create_simpcat_fragment('snmpd+disman.test_at.at') }
     end
   end
 end

--- a/spec/defines/disman/sched/cron_spec.rb
+++ b/spec/defines/disman/sched/cron_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::disman::sched::cron' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+disman.test_cron.cron') }
+      it { is_expected.to create_simpcat_fragment('snmpd+disman.test_cron.cron') }
     end
   end
 end

--- a/spec/defines/disman/sched/repeat_spec.rb
+++ b/spec/defines/disman/sched/repeat_spec.rb
@@ -17,7 +17,7 @@ describe 'snmpd::disman::sched::repeat' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+disman.test_repeat.sched') }
+      it { is_expected.to create_simpcat_fragment('snmpd+disman.test_repeat.sched') }
     end
   end
 end

--- a/spec/defines/disman/set_event_spec.rb
+++ b/spec/defines/disman/set_event_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::disman::set_event' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+disman.test_set_event.setevent') }
+      it { is_expected.to create_simpcat_fragment('snmpd+disman.test_set_event.setevent') }
     end
   end
 end

--- a/spec/defines/dlmod_spec.rb
+++ b/spec/defines/dlmod_spec.rb
@@ -13,7 +13,7 @@ describe 'snmpd::dlmod' do
       }}
 
       it { is_expected.to compile.with_all_deps }
-      it { is_expected.to create_concat_fragment('snmpd+test_dlmod.module') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_dlmod.module') }
       it { is_expected.to contain_class('snmpd') }
     end
   end

--- a/spec/defines/extension/arbitrary_spec.rb
+++ b/spec/defines/extension/arbitrary_spec.rb
@@ -16,7 +16,7 @@ describe 'snmpd::extension::arbitrary' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+ext.test_arbitrary.exec') }
+      it { is_expected.to create_simpcat_fragment('snmpd+ext.test_arbitrary.exec') }
     end
   end
 end

--- a/spec/defines/extension/mib_specific_spec.rb
+++ b/spec/defines/extension/mib_specific_spec.rb
@@ -16,7 +16,7 @@ describe 'snmpd::extension::mib_specific' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+ext.test_mib_specific.pass') }
+      it { is_expected.to create_simpcat_fragment('snmpd+ext.test_mib_specific.pass') }
     end
   end
 end

--- a/spec/defines/extension/perl/expression_spec.rb
+++ b/spec/defines/extension/perl/expression_spec.rb
@@ -14,7 +14,7 @@ describe 'snmpd::extension::perl::expression' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+ext.perl.exp.test_expression') }
+      it { is_expected.to create_simpcat_fragment('snmpd+ext.perl.exp.test_expression') }
     end
   end
 end

--- a/spec/defines/informsink_spec.rb
+++ b/spec/defines/informsink_spec.rb
@@ -14,7 +14,7 @@ describe 'snmpd::informsink' do
       }}
 
       it { is_expected.to compile.with_all_deps }
-      it { is_expected.to create_concat_fragment('snmpd+test_informsink.inform.sink') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_informsink.inform.sink') }
       it { is_expected.to contain_class('snmpd') }
     end
   end

--- a/spec/defines/inject_handler_spec.rb
+++ b/spec/defines/inject_handler_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::inject_handler' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_inject_handler.debug.inject') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_inject_handler.debug.inject') }
     end
   end
 end

--- a/spec/defines/interface_spec.rb
+++ b/spec/defines/interface_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::interface' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_interface.iface') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_interface.iface') }
     end
   end
 end

--- a/spec/defines/logmatch_spec.rb
+++ b/spec/defines/logmatch_spec.rb
@@ -16,7 +16,7 @@ describe 'snmpd::logmatch' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_logmatch.logmatch') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_logmatch.logmatch') }
     end
   end
 end

--- a/spec/defines/monitor_log_file_spec.rb
+++ b/spec/defines/monitor_log_file_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::monitor_log_file' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_monitor_log_file.logmon') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_monitor_log_file.logmon') }
     end
   end
 end

--- a/spec/defines/override_spec.rb
+++ b/spec/defines/override_spec.rb
@@ -16,7 +16,7 @@ describe 'snmpd::override' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_override_override.other') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_override_override.other') }
     end
   end
 end

--- a/spec/defines/procmon/proc_spec.rb
+++ b/spec/defines/procmon/proc_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::procmon::proc' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_proc.proc') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_proc.proc') }
     end
   end
 end

--- a/spec/defines/procmon/procfix_spec.rb
+++ b/spec/defines/procmon/procfix_spec.rb
@@ -16,7 +16,7 @@ describe 'snmpd::procmon::procfix' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_procfix.procfix') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_procfix.procfix') }
     end
   end
 end

--- a/spec/defines/proxy_spec.rb
+++ b/spec/defines/proxy_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::proxy' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_proxy.proxy') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_proxy.proxy') }
     end
   end
 end

--- a/spec/defines/smux/smuxpeer_spec.rb
+++ b/spec/defines/smux/smuxpeer_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::smux::smuxpeer' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+peer.test_smuxpeer.smux') }
+      it { is_expected.to create_simpcat_fragment('snmpd+peer.test_smuxpeer.smux') }
     end
   end
 end

--- a/spec/defines/smux/smuxsocket_spec.rb
+++ b/spec/defines/smux/smuxsocket_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::smux::smuxsocket' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+socket.test_smuxsocket.smux') }
+      it { is_expected.to create_simpcat_fragment('snmpd+socket.test_smuxsocket.smux') }
       it { is_expected.to create_iptables__add_tcp_stateful_listen('smux_test_smuxsocket') }
     end
   end

--- a/spec/defines/trap2sink_spec.rb
+++ b/spec/defines/trap2sink_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::trap2sink' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_trap2sink.trap2.sink') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_trap2sink.trap2.sink') }
     end
   end
 end

--- a/spec/defines/trapcommunity_spec.rb
+++ b/spec/defines/trapcommunity_spec.rb
@@ -11,7 +11,7 @@ describe 'snmpd::trapcommunity' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_trapcommunity.comstr') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_trapcommunity.comstr') }
     end
   end
 end

--- a/spec/defines/trapsess_spec.rb
+++ b/spec/defines/trapsess_spec.rb
@@ -11,7 +11,7 @@ describe 'snmpd::trapsess' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_trapsess.trapsess') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_trapsess.trapsess') }
     end
   end
 end

--- a/spec/defines/trapsink_spec.rb
+++ b/spec/defines/trapsink_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::trapsink' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_trapsink.trap.sink') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_trapsink.trap.sink') }
     end
   end
 end

--- a/spec/defines/useracl_spec.rb
+++ b/spec/defines/useracl_spec.rb
@@ -14,7 +14,7 @@ describe 'snmpd::useracl' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_useracl.auth') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_useracl.auth') }
     end
   end
 end

--- a/spec/defines/v1trapaddress_spec.rb
+++ b/spec/defines/v1trapaddress_spec.rb
@@ -11,7 +11,7 @@ describe 'snmpd::v1trapaddress' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+all.v1trapaddress') }
+      it { is_expected.to create_simpcat_fragment('snmpd+all.v1trapaddress') }
     end
   end
 end

--- a/spec/defines/vacm/access_spec.rb
+++ b/spec/defines/vacm/access_spec.rb
@@ -14,7 +14,7 @@ describe 'snmpd::vacm::access' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_access.access') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_access.access') }
     end
   end
 end

--- a/spec/defines/vacm/authaccess_spec.rb
+++ b/spec/defines/vacm/authaccess_spec.rb
@@ -16,7 +16,7 @@ describe 'snmpd::vacm::authaccess' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_authaccess.autha') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_authaccess.autha') }
     end
   end
 end

--- a/spec/defines/vacm/authcommunity_spec.rb
+++ b/spec/defines/vacm/authcommunity_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::vacm::authcommunity' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_authcommunity.authc') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_authcommunity.authc') }
     end
   end
 end

--- a/spec/defines/vacm/authgroup_spec.rb
+++ b/spec/defines/vacm/authgroup_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::vacm::authgroup' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_authgroup.authg') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_authgroup.authg') }
     end
   end
 end

--- a/spec/defines/vacm/authuser_spec.rb
+++ b/spec/defines/vacm/authuser_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::vacm::authuser' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_authuser.authu') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_authuser.authu') }
     end
   end
 end

--- a/spec/defines/vacm/com2sec_spec.rb
+++ b/spec/defines/vacm/com2sec_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::vacm::com2sec' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_com2sec.com2sec') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_com2sec.com2sec') }
     end
   end
 end

--- a/spec/defines/vacm/group_spec.rb
+++ b/spec/defines/vacm/group_spec.rb
@@ -15,7 +15,7 @@ describe 'snmpd::vacm::group' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_group.group') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_group.group') }
     end
   end
 end

--- a/spec/defines/vacm/setaccess_spec.rb
+++ b/spec/defines/vacm/setaccess_spec.rb
@@ -20,7 +20,7 @@ describe 'snmpd::vacm::setaccess' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_setaccess.autha') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_setaccess.autha') }
     end
   end
 end

--- a/spec/defines/vacm/view_spec.rb
+++ b/spec/defines/vacm/view_spec.rb
@@ -14,7 +14,7 @@ describe 'snmpd::vacm::access' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to contain_class('snmpd') }
-      it { is_expected.to create_concat_fragment('snmpd+test_access.access') }
+      it { is_expected.to create_simpcat_fragment('snmpd+test_access.access') }
     end
   end
 end


### PR DESCRIPTION
Updated to use the version of 'simpcat' that does not conflict with
'puppetlabs/concat'.

SIMP-1450 #comment Update to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted 'snmpd'
